### PR TITLE
Merge ruabmbua/master fork to Osspial/master

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,4 @@
 target
 Cargo.lock
+.idea/
+hidapi-rs.iml

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,8 +1,23 @@
-os:
-  - linux
-  - osx
-
 language: rust
+
+
+matrix:
+  include:
+    - env: TARGET=x86_64-unknown-linux-gnu FEATURE_FLAGS="linux-static-libusb"
+
+    - env: TARGET=x86_64-unknown-linux-gnu FEATURE_FLAGS="linux-static-hidraw"
+
+    - env: TARGET=x86_64-unknown-linux-gnu FEATURE_FLAGS="linux-shared-libusb"
+
+    - env: TARGET=x86_64-unknown-linux-gnu FEATURE_FLAGS="linux-shared-hidraw"
+
+    - env: TARGET=x86_64-apple-darwin
+      os: osx
+
+
+script:
+  - cargo build --verbose --no-default-features --features="${FEATURE_FLAGS}"
+  - cargo test --verbose --no-default-features --features="${FEATURE_FLAGS}"
 
 addons:
   apt:

--- a/.travis.yml
+++ b/.travis.yml
@@ -23,3 +23,5 @@ addons:
   apt:
     packages:
       - libusb-1.0-0-dev
+      - libudev-dev
+      - libhidapi-dev

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -15,8 +15,8 @@ links = "hidapi"
 documentation = "https://docs.rs/hidapi"
 
 [dependencies]
-libc = "0.2.15"
+libc = "0.2.33"
 
 [build-dependencies]
-gcc = "0.3"
-pkg-config = "0.3.5"
+cc = "1.0.3"
+pkg-config = "0.3.9"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -14,6 +14,11 @@ build = "build.rs"
 links = "hidapi"
 documentation = "https://docs.rs/hidapi"
 
+[features]
+default = []
+shared-libusb = []
+shared-hidraw = []
+
 [dependencies]
 libc = "0.2.15"
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -15,9 +15,11 @@ links = "hidapi"
 documentation = "https://docs.rs/hidapi"
 
 [features]
-default = []
-shared-libusb = []
-shared-hidraw = []
+default = ["linux-static-libusb"]
+linux-static-libusb = []
+linux-static-hidraw = []
+linux-shared-libusb = []
+linux-shared-hidraw = []
 
 [dependencies]
 libc = "0.2.33"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -16,6 +16,8 @@ documentation = "https://docs.rs/hidapi"
 
 [dependencies]
 libc = "0.2.33"
+failure = "0.1.2"
+failure_derive = "0.1.2"
 
 [build-dependencies]
 cc = "1.0.3"

--- a/README.md
+++ b/README.md
@@ -1,8 +1,8 @@
-# hidapi [![Build Status](https://travis-ci.org/Osspial/hidapi-rs.svg?branch=master)](https://travis-ci.org/Osspial/hidapi-rs) [![Version](https://img.shields.io/crates/v/hidapi.svg)](https://crates.io/crates/hidapi) [![License: MIT](https://img.shields.io/badge/License-MIT-yellow.svg)](https://github.com/Osspial/hidapi-rs/blob/master/LICENSE.txt) [![Documentation](https://docs.rs/hidapi/badge.svg)](https://docs.rs/hidapi)
+# hidapi [![Build Status](https://travis-ci.org/ruabmbua/hidapi-rs.svg?branch=master)](https://travis-ci.org/ruabmbua/hidapi-rs)
 
 This crate provides a rust abstraction over the features of the C library
 [hidapi](https://github.com/signal11/hidapi) by signal11. Based off of
-[hidapi_rust](https://github.com/ruabmbua/hidapi_rust) by ruabmbua.
+[hidapi-rs](https://github.com/Osspial/hidapi-rs) by Osspial.
 
 # Usage
 

--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-# hidapi [![Build Status](https://travis-ci.org/ruabmbua/hidapi-rs.svg?branch=master)](https://travis-ci.org/ruabmbua/hidapi-rs)
+# hidapi [![Build Status](https://travis-ci.org/ruabmbua/hidapi-rs.svg?branch=master)](https://travis-ci.org/ruabmbua/hidapi-rs) [![Version](https://img.shields.io/crates/v/hidapi.svg)](https://crates.io/crates/hidapi) [![License: MIT](https://img.shields.io/badge/License-MIT-yellow.svg)](https://github.com/Osspial/hidapi-rs/blob/master/LICENSE.txt) [![Documentation](https://docs.rs/hidapi/badge.svg)](https://docs.rs/hidapi)
 
 This crate provides a rust abstraction over the features of the C library
 [hidapi](https://github.com/signal11/hidapi) by signal11. Based off of

--- a/README.md
+++ b/README.md
@@ -9,10 +9,6 @@ This crate provides a rust abstraction over the features of the C library
 This crate is on [crates.io](https://crates.io/crates/hidapi) and can be
 used by adding `hidapi` to the dependencies in your project's `Cargo.toml`.
 
-```toml
-[dependencies]
-hidapi = "0.3"
-```
 # Example
 
 ```rust

--- a/build.rs
+++ b/build.rs
@@ -24,7 +24,7 @@ fn main() {
     compile();
 }
 
-#[cfg(target_os = "linux")]
+#[cfg(all(target_os = "linux", not(any(feature = "shared-libusb", feature = "shared-hidraw"))))]
 fn compile() {
     let mut config = gcc::Config::new();
     config.file("etc/hidapi/libusb/hid.c").include("etc/hidapi/hidapi");
@@ -33,6 +33,16 @@ fn compile() {
         config.include(path.to_str().expect("Failed to convert include path to str"));
     }
     config.compile("libhidapi.a");
+}
+
+#[cfg(all(target_os = "linux", feature = "shared-libusb", not(feature = "shared-hidraw")))]
+fn compile() {
+    pkg_config::probe_library("hidapi-libusb").expect("Unable to find hidapi-libusb");
+}
+
+#[cfg(all(target_os = "linux", feature = "shared-hidraw"))]
+fn compile() {
+    pkg_config::probe_library("hidapi-hidraw").expect("Unable to find hidapi-hidraw");
 }
 
 #[cfg(target_os = "windows")]

--- a/build.rs
+++ b/build.rs
@@ -29,7 +29,7 @@ fn main() {
         compile_linux();
     } else if target.contains("windows") {
         compile_windows();
-    } else if target.contains("macos") {
+    } else if target.contains("darwin") {
         compile_macos();
     } else {
         panic!("Unsupported target os for hidapi-rs");

--- a/build.rs
+++ b/build.rs
@@ -17,7 +17,7 @@
 // along with hidapi_rust.  If not, see <http://www.gnu.org/licenses/>.
 // *************************************************************************
 
-extern crate gcc;
+extern crate cc;
 extern crate pkg_config;
 
 fn main() {
@@ -26,7 +26,7 @@ fn main() {
 
 #[cfg(target_os = "linux")]
 fn compile() {
-    let mut config = gcc::Config::new();
+    let mut config = cc::Build::new();
     config.file("etc/hidapi/libusb/hid.c").include("etc/hidapi/hidapi");
     let lib = pkg_config::find_library("libusb-1.0").expect("Unable to find libusb-1.0");
     for path in lib.include_paths {
@@ -37,7 +37,7 @@ fn compile() {
 
 #[cfg(target_os = "windows")]
 fn compile() {
-    gcc::Config::new()
+    cc::Build::new()
         .file("etc/hidapi/windows/hid.c")
         .include("etc/hidapi/hidapi")
         .compile("libhidapi.a");
@@ -46,7 +46,7 @@ fn compile() {
 
 #[cfg(target_os = "macos")]
 fn compile() {
-    gcc::Config::new()
+    cc::Build::new()
         .file("etc/hidapi/mac/hid.c")
         .include("etc/hidapi/hidapi")
         .compile("libhidapi.a");

--- a/build.rs
+++ b/build.rs
@@ -20,38 +20,93 @@
 extern crate cc;
 extern crate pkg_config;
 
+use std::env;
+
 fn main() {
-    compile();
-}
+    let target = env::var("TARGET").unwrap();
 
-#[cfg(all(target_os = "linux", not(any(feature = "shared-libusb", feature = "shared-hidraw"))))]
-fn compile() {
-    let mut config = cc::Build::new();
-    config
-        .file("etc/hidapi/libusb/hid.c")
-        .include("etc/hidapi/hidapi");
-    let lib = pkg_config::find_library("libusb-1.0").expect("Unable to find libusb-1.0");
-    for path in lib.include_paths {
-        config.include(
-            path.to_str()
-                .expect("Failed to convert include path to str"),
-        );
+    if target.contains("linux") {
+        compile_linux();
+    } else if target.contains("windows") {
+        compile_windows();
+    } else if target.contains("macos") {
+        compile_macos();
+    } else {
+        panic!("Unsupported target os for hidapi-rs");
     }
-    config.compile("libhidapi.a");
 }
 
-#[cfg(all(target_os = "linux", feature = "shared-libusb", not(feature = "shared-hidraw")))]
-fn compile() {
-    pkg_config::probe_library("hidapi-libusb").expect("Unable to find hidapi-libusb");
+fn compile_linux() {
+    // First check the features enabled for the crate.
+    // Only one linux backend should be enabled at a time.
+
+    let avail_backends: [(&'static str, Box<Fn()>); 4] = [
+        (
+            "LINUX_STATIC_HIDRAW",
+            Box::new(|| {
+                let mut config = cc::Build::new();
+                config
+                    .file("etc/hidapi/linux/hid.c")
+                    .include("etc/hidapi/hidapi");
+                pkg_config::probe_library("libudev").expect("Unable to find libudev");
+                config.compile("libhidapi.a");
+            }),
+        ),
+        (
+            "LINUX_STATIC_LIBUSB",
+            Box::new(|| {
+                let mut config = cc::Build::new();
+                config
+                    .file("etc/hidapi/libusb/hid.c")
+                    .include("etc/hidapi/hidapi");
+                let lib =
+                    pkg_config::find_library("libusb-1.0").expect("Unable to find libusb-1.0");
+                for path in lib.include_paths {
+                    config.include(
+                        path.to_str()
+                            .expect("Failed to convert include path to str"),
+                    );
+                }
+                config.compile("libhidapi.a");
+            }),
+        ),
+        (
+            "LINUX_SHARED_HIDRAW",
+            Box::new(|| {
+                pkg_config::probe_library("hidapi-hidraw").expect("Unable to find hidapi-hidraw");
+            }),
+        ),
+        (
+            "LINUX_SHARED_LIBUSB",
+            Box::new(|| {
+                pkg_config::probe_library("hidapi-libusb").expect("Unable to find hidapi-libusb");
+            }),
+        ),
+    ];
+
+    let mut backends = avail_backends
+        .iter()
+        .filter(|f| env::var(format!("CARGO_FEATURE_{}", f.0)).is_ok());
+
+    if backends.clone().count() != 1 {
+        panic!("Exactly one linux hidapi backend must be selected.");
+    }
+
+    // Build it!
+    (backends.next().unwrap().1)();
 }
 
-#[cfg(all(target_os = "linux", feature = "shared-hidraw"))]
-fn compile() {
-    pkg_config::probe_library("hidapi-hidraw").expect("Unable to find hidapi-hidraw");
-}
+//#[cfg(all(feature = "shared-libusb", not(feature = "shared-hidraw")))]
+//fn compile_linux() {
+//
+//}
+//
+//#[cfg(all(feature = "shared-hidraw"))]
+//fn compile_linux() {
+//
+//}
 
-#[cfg(target_os = "windows")]
-fn compile() {
+fn compile_windows() {
     cc::Build::new()
         .file("etc/hidapi/windows/hid.c")
         .include("etc/hidapi/hidapi")
@@ -59,8 +114,7 @@ fn compile() {
     println!("cargo:rustc-link-lib=setupapi");
 }
 
-#[cfg(target_os = "macos")]
-fn compile() {
+fn compile_macos() {
     cc::Build::new()
         .file("etc/hidapi/mac/hid.c")
         .include("etc/hidapi/hidapi")

--- a/build.rs
+++ b/build.rs
@@ -27,10 +27,15 @@ fn main() {
 #[cfg(target_os = "linux")]
 fn compile() {
     let mut config = cc::Build::new();
-    config.file("etc/hidapi/libusb/hid.c").include("etc/hidapi/hidapi");
+    config
+        .file("etc/hidapi/libusb/hid.c")
+        .include("etc/hidapi/hidapi");
     let lib = pkg_config::find_library("libusb-1.0").expect("Unable to find libusb-1.0");
     for path in lib.include_paths {
-        config.include(path.to_str().expect("Failed to convert include path to str"));
+        config.include(
+            path.to_str()
+                .expect("Failed to convert include path to str"),
+        );
     }
     config.compile("libhidapi.a");
 }

--- a/examples/co2mon.rs
+++ b/examples/co2mon.rs
@@ -5,7 +5,6 @@
     It's also based on the Oleg Bulatov's work (https://github.com/dmage/co2mon)
 ****************************************************************************/
 
-
 //! Opens a KIT MT 8057 CO2 detector and reads data from it. This
 //! example will not work unless such an HID is plugged in to your system.
 
@@ -31,7 +30,7 @@ enum CO2Result {
 }
 
 fn decode_temperature(value: u16) -> f32 {
-    (value as f32)*0.0625 - 273.15
+    (value as f32) * 0.0625 - 273.15
 }
 
 fn decode_buf(buf: [u8; PACKET_SIZE]) -> CO2Result {
@@ -43,20 +42,19 @@ fn decode_buf(buf: [u8; PACKET_SIZE]) -> CO2Result {
         (buf[7] << 5) | (buf[1] >> 3),
         (buf[1] << 5) | (buf[6] >> 3),
         (buf[6] << 5) | (buf[5] >> 3),
-        (buf[5] << 5) | (buf[3] >> 3)
+        (buf[5] << 5) | (buf[3] >> 3),
     ];
 
     let magic_word = b"Htemp99e";
     for i in 0..PACKET_SIZE {
-        let sub_val:u8 = (magic_word[i] << 4) | (magic_word[i] >> 4);
+        let sub_val: u8 = (magic_word[i] << 4) | (magic_word[i] >> 4);
         res[i] = u8::overflowing_sub(res[i], sub_val).0;
     }
 
     if res[4] != 0x0d {
         return CO2Result::Error("Unexpected data (data[4] != 0x0d)");
     }
-    let checksum = u8::overflowing_add(
-        u8::overflowing_add(res[0], res[1]).0, res[2]).0;
+    let checksum = u8::overflowing_add(u8::overflowing_add(res[0], res[1]).0, res[2]).0;
     if checksum != res[3] {
         return CO2Result::Error("Checksum error");
     }
@@ -66,12 +64,11 @@ fn decode_buf(buf: [u8; PACKET_SIZE]) -> CO2Result {
         CODE_TEMPERATURE => CO2Result::Temperature(decode_temperature(val)),
         CODE_CONCENTRATION => {
             if val > 3000 {
-                CO2Result::Error(
-                    "Concentration bigger than 3000 (uninitialized device?)")
+                CO2Result::Error("Concentration bigger than 3000 (uninitialized device?)")
             } else {
                 CO2Result::Concentration(val)
             }
-        },
+        }
         _ => CO2Result::Unknown(res[0], val),
     }
 }
@@ -83,7 +80,7 @@ fn open_device(api: &HidApi) -> HidDevice {
             Err(err) => {
                 println!("{}", err);
                 sleep(Duration::from_secs(RETRY_SEC));
-            },
+            }
         }
     }
 }
@@ -93,24 +90,33 @@ fn main() {
 
     let dev = open_device(&api);
 
-    dev.send_feature_report(&[0; PACKET_SIZE]).expect("Feature report failed");
+    dev.send_feature_report(&[0; PACKET_SIZE])
+        .expect("Feature report failed");
 
-    println!("Manufacurer:\t{}", dev.get_manufacturer_string()
-        .expect("Failed to read manufacurer string"));
-    println!("Product:\t{}", dev.get_product_string()
-        .expect("Failed to read product string"));
-    println!("Serial number:\t{}", dev.get_serial_number_string()
-        .expect("Failed to read serial number"));
+    println!(
+        "Manufacurer:\t{:?}",
+        dev.get_manufacturer_string()
+            .expect("Failed to read manufacurer string")
+    );
+    println!(
+        "Product:\t{:?}",
+        dev.get_product_string()
+            .expect("Failed to read product string")
+    );
+    println!(
+        "Serial number:\t{:?}",
+        dev.get_serial_number_string()
+            .expect("Failed to read serial number")
+    );
 
     loop {
         let mut buf = [0; PACKET_SIZE];
         match dev.read_timeout(&mut buf[..], HID_TIMEOUT) {
             Ok(PACKET_SIZE) => (),
             Ok(res) => {
-                println!("Error: unexpected length of data: {}/{}",
-                    res, PACKET_SIZE);
+                println!("Error: unexpected length of data: {}/{}", res, PACKET_SIZE);
                 continue;
-            },
+            }
             Err(err) => {
                 println!("Error: {:}", err);
                 sleep(Duration::from_secs(RETRY_SEC));
@@ -124,7 +130,7 @@ fn main() {
             CO2Result::Error(val) => {
                 println!("Error:\t{}", val);
                 sleep(Duration::from_secs(RETRY_SEC));
-            },
+            }
         }
     }
 }

--- a/examples/lshid.rs
+++ b/examples/lshid.rs
@@ -4,7 +4,6 @@
     This file is part of hidapi-rs, based on hidapi_rust by Roland Ruckerbauer.
 ****************************************************************************/
 
-
 //! Prints out a list of HID devices
 
 extern crate hidapi;

--- a/examples/lshid.rs
+++ b/examples/lshid.rs
@@ -11,11 +11,16 @@ extern crate hidapi;
 use hidapi::HidApi;
 
 fn main() {
-    println!("Printing all available hid devices.");
+    println!("Printing all available hid devices:");
 
-    let api = HidApi::new().unwrap();
-
-    for device in api.devices() {
-        println!("{:#?}", device);
+    match HidApi::new() {
+        Ok(api) => {
+            for device in api.devices() {
+                println!("{:#?}", device);
+            }
+        },
+        Err(e) => {
+            eprintln!("Error: {}", e);
+        },
     }
 }

--- a/examples/lshid.rs
+++ b/examples/lshid.rs
@@ -18,9 +18,9 @@ fn main() {
             for device in api.devices() {
                 println!("{:#?}", device);
             }
-        },
+        }
         Err(e) => {
             eprintln!("Error: {}", e);
-        },
+        }
     }
 }

--- a/examples/lshid.rs
+++ b/examples/lshid.rs
@@ -15,7 +15,7 @@ fn main() {
 
     let api = HidApi::new().unwrap();
 
-    for device in &api.devices() {
+    for device in api.devices() {
         println!("{:#?}", device);
     }
 }

--- a/examples/readhid.rs
+++ b/examples/readhid.rs
@@ -4,7 +4,6 @@
     This file is part of hidapi-rs, based on hidapi_rust by Roland Ruckerbauer.
 ****************************************************************************/
 
-
 //! Opens a Thrustmaster T-Flight HOTAS X HID and reads data from it. This
 //! example will not work unless such an HID is plugged in to your system.
 //! Will update in the future to support all HIDs.
@@ -14,7 +13,6 @@ extern crate hidapi;
 use hidapi::HidApi;
 
 fn main() {
-
     let api = HidApi::new().expect("Failed to create API instance");
 
     let joystick = api.open(1103, 45320).expect("Failed to open device");
@@ -29,8 +27,6 @@ fn main() {
             data_string.push_str(&(u.to_string() + "\t"));
         }
 
-
         println!("{}", data_string);
-
     }
 }

--- a/examples/static_lifetime_bound.rs
+++ b/examples/static_lifetime_bound.rs
@@ -1,0 +1,42 @@
+/****************************************************************************
+Copyright (c) 2015 Osspial All Rights Reserved.
+
+This file is part of hidapi-rs, based on hidapi_rust by Roland Ruckerbauer.
+****************************************************************************/
+
+//! This example shows the added possibility (after version 0.4.1),
+//! to move devices into a function / or closure with static lifetime bounds.
+
+extern crate hidapi;
+
+use hidapi::{HidApi, HidDevice};
+use std::rc::Rc;
+
+fn main() {
+    let _dev = test_lt();
+}
+
+fn requires_static_lt_bound<F: Fn() + 'static>(f: F) {
+    f();
+}
+
+fn test_lt() -> Rc<HidDevice> {
+    let api = HidApi::new().expect("Hidapi init failed");
+
+    let devices = api.devices();
+
+    let dev_info = devices.get(0)
+        .expect("There is not a single hid device available");
+
+    println!("{:#?}", dev_info);
+
+    let dev = Rc::new(api.open(dev_info.vendor_id, dev_info.product_id)
+        .expect("Can not open device"));
+
+    let dev_1 = dev.clone();
+    requires_static_lt_bound(move || {
+        println!("{}", dev_1.check_error().unwrap()); //<! Can be captured by closure with static lt
+    });
+
+    dev //<! Can be returned from a function, which exceeds the lifetime of the API context
+}

--- a/examples/static_lifetime_bound.rs
+++ b/examples/static_lifetime_bound.rs
@@ -25,13 +25,16 @@ fn test_lt() -> Rc<HidDevice> {
 
     let devices = api.devices();
 
-    let dev_info = devices.get(0)
+    let dev_info = devices
+        .get(0)
         .expect("There is not a single hid device available");
 
     println!("{:#?}", dev_info);
 
-    let dev = Rc::new(api.open(dev_info.vendor_id, dev_info.product_id)
-        .expect("Can not open device"));
+    let dev = Rc::new(
+        api.open(dev_info.vendor_id, dev_info.product_id)
+            .expect("Can not open device"),
+    );
 
     let dev_1 = dev.clone();
     requires_static_lt_bound(move || {

--- a/src/error.rs
+++ b/src/error.rs
@@ -1,0 +1,34 @@
+use libc::wchar_t;
+use failure::{Compat, Error};
+
+#[derive(Debug, Fail)]
+pub enum HidError {
+    #[fail(display = "hidapi error: {}", message)]
+    HidApiError { message: String },
+    #[fail(
+        display = "hidapi error: (could not get error message), caused by: {}",
+        cause
+    )]
+    HidApiErrorEmptyWithCause {
+        #[cause]
+        cause: Compat<Error>,
+    },
+    #[fail(display = "hidapi error: (could not get error message)")]
+    HidApiErrorEmpty,
+    #[fail(display = "failed converting {:#X} to rust char", wide_char)]
+    FromWideCharError { wide_char: wchar_t },
+    #[fail(display = "Failed to initialize hidapi (maybe initialized before?)")]
+    InitializationError,
+    #[fail(display = "Failed opening hid device")]
+    OpenHidDeviceError,
+    #[fail(display = "Invalid data: size can not be 0")]
+    InvalidZeroSizeData,
+    #[fail(
+        display = "Failed to send all data: only sent {} out of {} bytes",
+        sent,
+        all
+    )]
+    IncompleteSendError { sent: usize, all: usize },
+    #[fail(display = "Can not set blocking mode to '{}'", mode)]
+    SetBlockingModeError { mode: &'static str },
+}

--- a/src/error.rs
+++ b/src/error.rs
@@ -4,8 +4,9 @@
 // This file is part of hidapi-rs, based on hidapi-rs by Osspial
 // **************************************************************************
 
-use libc::wchar_t;
+use super::HidDeviceInfo;
 use failure::{Compat, Error};
+use libc::wchar_t;
 
 #[derive(Debug, Fail)]
 pub enum HidError {
@@ -37,4 +38,6 @@ pub enum HidError {
     IncompleteSendError { sent: usize, all: usize },
     #[fail(display = "Can not set blocking mode to '{}'", mode)]
     SetBlockingModeError { mode: &'static str },
+    #[fail(display = "Can not open hid device with: {:?}", device_info)]
+    OpenHidDeviceWithDeviceInfoError { device_info: HidDeviceInfo },
 }

--- a/src/error.rs
+++ b/src/error.rs
@@ -1,3 +1,9 @@
+// **************************************************************************
+// Copyright (c) 2018 Roland Ruckerbauer All Rights Reserved.
+//
+// This file is part of hidapi-rs, based on hidapi-rs by Osspial
+// **************************************************************************
+
 use libc::wchar_t;
 use failure::{Compat, Error};
 

--- a/src/ffi.rs
+++ b/src/ffi.rs
@@ -3,10 +3,8 @@
 ///
 /// This file is part of hidapi-rs, based on hidapi_rust by Roland Ruckerbauer.
 /// *************************************************************************
-
 // For documentation look at the corresponding C header file hidapi.h
-
-use libc::{c_void, c_ushort, wchar_t, c_int, c_uchar, size_t, c_char};
+use libc::{c_char, c_int, c_uchar, c_ushort, c_void, size_t, wchar_t};
 
 pub type HidDevice = c_void;
 
@@ -31,44 +29,52 @@ extern "C" {
     pub fn hid_exit() -> c_int;
     pub fn hid_enumerate(vendor_id: c_ushort, product_id: c_ushort) -> *mut HidDeviceInfo;
     pub fn hid_free_enumeration(hid_device_info: *mut HidDeviceInfo);
-    pub fn hid_open(vendor_id: c_ushort,
-                    product_id: c_ushort,
-                    serial_number: *const wchar_t)
-                    -> *mut HidDevice;
+    pub fn hid_open(
+        vendor_id: c_ushort,
+        product_id: c_ushort,
+        serial_number: *const wchar_t,
+    ) -> *mut HidDevice;
     pub fn hid_open_path(path: *const c_char) -> *mut HidDevice;
     pub fn hid_write(device: *mut HidDevice, data: *const c_uchar, length: size_t) -> c_int;
-    pub fn hid_read_timeout(device: *mut HidDevice,
-                            data: *mut c_uchar,
-                            length: size_t,
-                            milleseconds: c_int)
-                            -> c_int;
+    pub fn hid_read_timeout(
+        device: *mut HidDevice,
+        data: *mut c_uchar,
+        length: size_t,
+        milleseconds: c_int,
+    ) -> c_int;
     pub fn hid_read(device: *mut HidDevice, data: *mut c_uchar, length: size_t) -> c_int;
     pub fn hid_set_nonblocking(device: *mut HidDevice, nonblock: c_int) -> c_int;
-    pub fn hid_send_feature_report(device: *mut HidDevice,
-                                   data: *const c_uchar,
-                                   length: size_t)
-                                   -> c_int;
-    pub fn hid_get_feature_report(device: *mut HidDevice,
-                                  data: *mut c_uchar,
-                                  length: size_t)
-                                  -> c_int;
+    pub fn hid_send_feature_report(
+        device: *mut HidDevice,
+        data: *const c_uchar,
+        length: size_t,
+    ) -> c_int;
+    pub fn hid_get_feature_report(
+        device: *mut HidDevice,
+        data: *mut c_uchar,
+        length: size_t,
+    ) -> c_int;
     pub fn hid_close(device: *mut HidDevice);
-    pub fn hid_get_manufacturer_string(device: *mut HidDevice,
-                                       string: *mut wchar_t,
-                                       maxlen: size_t)
-                                       -> c_int;
-    pub fn hid_get_product_string(device: *mut HidDevice,
-                                  string: *mut wchar_t,
-                                  maxlen: size_t)
-                                  -> c_int;
-    pub fn hid_get_serial_number_string(device: *mut HidDevice,
-                                        string: *mut wchar_t,
-                                        maxlen: size_t)
-                                        -> c_int;
-    pub fn hid_get_indexed_string(device: *mut HidDevice,
-                                  string_index: c_int,
-                                  string: *mut wchar_t,
-                                  maxlen: size_t)
-                                  -> c_int;
+    pub fn hid_get_manufacturer_string(
+        device: *mut HidDevice,
+        string: *mut wchar_t,
+        maxlen: size_t,
+    ) -> c_int;
+    pub fn hid_get_product_string(
+        device: *mut HidDevice,
+        string: *mut wchar_t,
+        maxlen: size_t,
+    ) -> c_int;
+    pub fn hid_get_serial_number_string(
+        device: *mut HidDevice,
+        string: *mut wchar_t,
+        maxlen: size_t,
+    ) -> c_int;
+    pub fn hid_get_indexed_string(
+        device: *mut HidDevice,
+        string_index: c_int,
+        string: *mut wchar_t,
+        maxlen: size_t,
+    ) -> c_int;
     pub fn hid_error(device: *mut HidDevice) -> *const wchar_t;
 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -16,12 +16,12 @@
 //!
 //! ```rust,no_run
 //! extern crate hidapi;
-//! 
+//!
 //! use hidapi::HidApi;
-//! 
+//!
 //! fn main() {
 //!     println!("Printing all available hid devices:");
-//! 
+//!
 //!     match HidApi::new() {
 //!         Ok(api) => {
 //!             for device in api.devices() {

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -12,34 +12,27 @@
 //! This crate is [on crates.io](https://crates.io/crates/hidapi) and can be
 //! used by adding `hidapi` to the dependencies in your project's `Cargo.toml`.
 //!
-//! ```toml
-//! [dependencies]
-//! hidapi = "0.4"
-//! ```
 //! # Example
 //!
 //! ```rust,no_run
 //! extern crate hidapi;
-//!
-//! let api = hidapi::HidApi::new().unwrap();
-//! // Print out information about all connected devices
-//! for device in &api.devices() {
-//!     println!("{:#?}", device);
+//! 
+//! use hidapi::HidApi;
+//! 
+//! fn main() {
+//!     println!("Printing all available hid devices:");
+//! 
+//!     match HidApi::new() {
+//!         Ok(api) => {
+//!             for device in api.devices() {
+//!                 println!("{:#?}", device);
+//!             }
+//!         },
+//!         Err(e) => {
+//!             eprintln!("Error: {}", e);
+//!         },
+//!     }
 //! }
-//!
-//! // Connect to device using its VID and PID
-//! let (VID, PID) = (0x0123, 0x3456);
-//! let device = api.open(VID, PID).unwrap();
-//!
-//! // Read data from device
-//! let mut buf = [0u8; 8];
-//! let res = device.read(&mut buf[..]).unwrap();
-//! println!("Read: {:?}", &buf[..res]);
-//!
-//! // Write data to device
-//! let buf = [0u8, 1, 2, 3, 4];
-//! let res = device.write(&buf).unwrap();
-//! println!("Wrote: {:?} byte(s)", res);
 //! ```
 
 #[macro_use]

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -47,7 +47,6 @@ mod ffi;
 
 use std::ffi::CStr;
 use std::ffi::CString;
-use std::marker::PhantomData;
 use std::rc::Rc;
 use std::mem::ManuallyDrop;
 use libc::{wchar_t, size_t, c_int};

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -41,17 +41,23 @@
 //! let res = device.write(&buf).unwrap();
 //! println!("Wrote: {:?} byte(s)", res);
 //! ```
+
+#[macro_use]
+extern crate failure_derive;
+extern crate failure;
 extern crate libc;
 
+mod error;
 mod ffi;
 
+use libc::{c_int, size_t, wchar_t};
 use std::ffi::CStr;
 use std::ffi::CString;
-use std::rc::Rc;
 use std::mem::ManuallyDrop;
-use libc::{wchar_t, size_t, c_int};
+use std::rc::Rc;
+use failure::Error;
 
-pub type HidError = &'static str;
+pub use error::HidError;
 pub type HidResult<T> = Result<T, HidError>;
 const STRING_BUF_LEN: usize = 128;
 
@@ -65,13 +71,13 @@ impl HidApiLock {
             // Initialize the HID and prevent other HIDs from being created
             unsafe {
                 if ffi::hid_init() == -1 {
-                    return Err("Failed to init hidapi");
+                    return Err(HidError::InitializationError);
                 }
                 HID_API_LOCK = true;
                 Ok(HidApiLock)
             }
         } else {
-            Err("HidApi already in use")
+            Err(HidError::InitializationError)
         }
     }
 }
@@ -100,19 +106,19 @@ impl HidApi {
         let lock = HidApiLock::acquire()?;
 
         Ok(HidApi {
-            devices: unsafe { HidApi::get_hid_device_info_vector() },
+            devices: unsafe { HidApi::get_hid_device_info_vector()? },
             _lock: Rc::new(lock),
         })
-
     }
 
     /// Refresh devices list and information about them (to access them use
     /// `devices()` method)
-    pub fn refresh_devices(&mut self) {
-        self.devices = unsafe { HidApi::get_hid_device_info_vector() };
+    pub fn refresh_devices(&mut self) -> HidResult<()> {
+        self.devices = unsafe { HidApi::get_hid_device_info_vector()? };
+        Ok(())
     }
 
-    unsafe fn get_hid_device_info_vector() -> Vec<HidDeviceInfo> {
+    unsafe fn get_hid_device_info_vector() -> HidResult<Vec<HidDeviceInfo>> {
         let mut device_vector = Vec::with_capacity(8);
 
         let enumeration = ffi::hid_enumerate(0, 0);
@@ -120,17 +126,16 @@ impl HidApi {
             let mut current_device = enumeration;
 
             while !current_device.is_null() {
-                device_vector.push(conv_hid_device_info(current_device));
+                device_vector.push(conv_hid_device_info(current_device)?);
                 current_device = (*current_device).next;
             }
-
         }
 
         if !enumeration.is_null() {
             ffi::hid_free_enumeration(enumeration);
         }
 
-        device_vector
+        Ok(device_vector)
     }
 
     /// Returns list of objects containing information about connected devices
@@ -143,7 +148,7 @@ impl HidApi {
         let device = unsafe { ffi::hid_open(vid, pid, std::ptr::null()) };
 
         if device.is_null() {
-            Err("Unable to open hid device")
+            Err(HidError::OpenHidDeviceError)
         } else {
             Ok(HidDevice {
                 _hid_device: device,
@@ -159,7 +164,7 @@ impl HidApi {
         chars.push(0 as wchar_t);
         let device = unsafe { ffi::hid_open(vid, pid, chars.as_ptr()) };
         if device.is_null() {
-            Err("Unable to open hid device")
+            Err(HidError::OpenHidDeviceError)
         } else {
             Ok(HidDevice {
                 _hid_device: device,
@@ -174,7 +179,7 @@ impl HidApi {
         let device = unsafe { ffi::hid_open_path(device_path.as_ptr()) };
 
         if device.is_null() {
-            Err("Unable to open hid device")
+            Err(HidError::OpenHidDeviceError)
         } else {
             Ok(HidDevice {
                 _hid_device: device,
@@ -184,42 +189,46 @@ impl HidApi {
     }
 }
 
-/// Converts a pointer to a `wchar_t` to a string
-unsafe fn wchar_to_string(wstr: *const wchar_t) -> HidResult<String> {
+/// Converts a pointer to a `wchar_t` to a optional string
+unsafe fn wchar_to_string(wstr: *const wchar_t) -> HidResult<Option<String>> {
     if wstr.is_null() {
-        return Err("Null pointer!");
+        return Ok(None);
     }
 
     let mut char_vector: Vec<char> = Vec::with_capacity(8);
     let mut index: isize = 0;
 
-    while *wstr.offset(index) != 0 {
+    let o = |i| *wstr.offset(i);
+
+    while o(index) != 0 {
         use std::char;
-        char_vector.push(match char::from_u32(*wstr.offset(index) as u32) {
+        char_vector.push(match char::from_u32(o(index) as u32) {
             Some(ch) => ch,
-            None => return Err("Unable to add next char"),
+            None => Err(HidError::FromWideCharError {
+                wide_char: o(index),
+            })?,
         });
 
         index += 1;
     }
 
-    Ok(char_vector.into_iter().collect())
+    Ok(Some(char_vector.into_iter().collect()))
 }
 
 /// Convert the CFFI `HidDeviceInfo` struct to a native `HidDeviceInfo` struct
-unsafe fn conv_hid_device_info(src: *mut ffi::HidDeviceInfo) -> HidDeviceInfo {
-    HidDeviceInfo {
+unsafe fn conv_hid_device_info(src: *mut ffi::HidDeviceInfo) -> HidResult<HidDeviceInfo> {
+    Ok(HidDeviceInfo {
         path: CStr::from_ptr((*src).path).to_owned(),
         vendor_id: (*src).vendor_id,
         product_id: (*src).product_id,
-        serial_number: wchar_to_string((*src).serial_number).ok(),
+        serial_number: wchar_to_string((*src).serial_number)?,
         release_number: (*src).release_number,
-        manufacturer_string: wchar_to_string((*src).manufacturer_string).ok(),
-        product_string: wchar_to_string((*src).product_string).ok(),
+        manufacturer_string: wchar_to_string((*src).manufacturer_string)?,
+        product_string: wchar_to_string((*src).product_string)?,
         usage_page: (*src).usage_page,
         usage: (*src).usage,
         interface_number: (*src).interface_number,
-    }
+    })
 }
 
 #[derive(Debug, Clone)]
@@ -259,18 +268,8 @@ impl HidDevice {
     fn check_size(&self, res: i32) -> HidResult<usize> {
         if res == -1 {
             match self.check_error() {
-                Ok(err) => {
-                    if err.is_empty() {
-                        Err("Undetected error")
-                    } else {
-                        println!("{:?}", err);
-                        Err("Detected error")
-                    }
-                }
-                Err(_) => {
-                    // Err(err)
-                    Err("Failed to retrieve error message")
-                }
+                Ok(err) => Err(err),
+                Err(e) => Err(e),
             }
         } else {
             Ok(res as usize)
@@ -278,10 +277,15 @@ impl HidDevice {
     }
 
     /// Get a string describing the last error which occurred.
-    pub fn check_error(&self) -> HidResult<String> {
-        unsafe { wchar_to_string(ffi::hid_error(self._hid_device)) }
+    pub fn check_error(&self) -> HidResult<HidError> {
+        Ok(HidError::HidApiError {
+            message: unsafe {
+                wchar_to_string(ffi::hid_error(self._hid_device))
+                    .map_err(|e| HidError::HidApiErrorEmptyWithCause { cause: Error::from(e).compat() })?
+                    .ok_or(HidError::HidApiErrorEmpty)?
+            },
+        })
     }
-
 
     /// The first byte of `data` must contain the Report ID. For
     /// devices which only support a single report, this must be set
@@ -297,7 +301,7 @@ impl HidDevice {
     /// the Control Endpoint (Endpoint 0).
     pub fn write(&self, data: &[u8]) -> HidResult<usize> {
         if data.len() == 0 {
-            return Err("Data must contain at least one byte");
+            return Err(HidError::InvalidZeroSizeData);
         }
         let res = unsafe { ffi::hid_write(self._hid_device, data.as_ptr(), data.len() as size_t) };
         self.check_size(res)
@@ -317,10 +321,12 @@ impl HidDevice {
     /// blocking wait.
     pub fn read_timeout(&self, buf: &mut [u8], timeout: i32) -> HidResult<usize> {
         let res = unsafe {
-            ffi::hid_read_timeout(self._hid_device,
-                                  buf.as_mut_ptr(),
-                                  buf.len() as size_t,
-                                  timeout)
+            ffi::hid_read_timeout(
+                self._hid_device,
+                buf.as_mut_ptr(),
+                buf.len() as size_t,
+                timeout,
+            )
         };
         self.check_size(res)
     }
@@ -338,14 +344,17 @@ impl HidDevice {
     /// In this example, the length passed in would be 17.
     pub fn send_feature_report(&self, data: &[u8]) -> HidResult<()> {
         if data.len() == 0 {
-            return Err("Data must contain at least one byte");
+            return Err(HidError::InvalidZeroSizeData);
         }
         let res = unsafe {
             ffi::hid_send_feature_report(self._hid_device, data.as_ptr(), data.len() as size_t)
         };
-        let res = try!(self.check_size(res));
+        let res = self.check_size(res)?;
         if res != data.len() {
-            Err("Failed to send feature report completely")
+            Err(HidError::IncompleteSendError {
+                sent: res,
+                all: data.len(),
+            })
         } else {
             Ok(())
         }
@@ -371,58 +380,71 @@ impl HidDevice {
             ffi::hid_set_nonblocking(self._hid_device, if blocking { 0i32 } else { 1i32 })
         };
         if res == -1 {
-            Err("Failed to set blocking mode")
+            Err(HidError::SetBlockingModeError {
+                mode: match blocking {
+                    true => "blocking",
+                    false => "not blocking",
+                },
+            })
         } else {
             Ok(())
         }
     }
 
     /// Get The Manufacturer String from a HID device.
-    pub fn get_manufacturer_string(&self) -> HidResult<String> {
+    pub fn get_manufacturer_string(&self) -> HidResult<Option<String>> {
         let mut buf = [0 as wchar_t; STRING_BUF_LEN];
         let res = unsafe {
-            ffi::hid_get_manufacturer_string(self._hid_device,
-                                             buf.as_mut_ptr(),
-                                             STRING_BUF_LEN as size_t)
+            ffi::hid_get_manufacturer_string(
+                self._hid_device,
+                buf.as_mut_ptr(),
+                STRING_BUF_LEN as size_t,
+            )
         };
-        let res = try!(self.check_size(res));
+        let res = self.check_size(res)?;
         unsafe { wchar_to_string(buf[..res].as_ptr()) }
     }
 
     /// Get The Manufacturer String from a HID device.
-    pub fn get_product_string(&self) -> HidResult<String> {
+    pub fn get_product_string(&self) -> HidResult<Option<String>> {
         let mut buf = [0 as wchar_t; STRING_BUF_LEN];
         let res = unsafe {
-            ffi::hid_get_product_string(self._hid_device,
-                                        buf.as_mut_ptr(),
-                                        STRING_BUF_LEN as size_t)
+            ffi::hid_get_product_string(
+                self._hid_device,
+                buf.as_mut_ptr(),
+                STRING_BUF_LEN as size_t,
+            )
         };
-        let res = try!(self.check_size(res));
+        let res = self.check_size(res)?;
         unsafe { wchar_to_string(buf[..res].as_ptr()) }
     }
 
     /// Get The Serial Number String from a HID device.
-    pub fn get_serial_number_string(&self) -> HidResult<String> {
+    pub fn get_serial_number_string(&self) -> HidResult<Option<String>> {
         let mut buf = [0 as wchar_t; STRING_BUF_LEN];
         let res = unsafe {
-            ffi::hid_get_serial_number_string(self._hid_device,
-                                              buf.as_mut_ptr(),
-                                              STRING_BUF_LEN as size_t)
+            ffi::hid_get_serial_number_string(
+                self._hid_device,
+                buf.as_mut_ptr(),
+                STRING_BUF_LEN as size_t,
+            )
         };
-        let res = try!(self.check_size(res));
+        let res = self.check_size(res)?;
         unsafe { wchar_to_string(buf[..res].as_ptr()) }
     }
 
     /// Get a string from a HID device, based on its string index.
-    pub fn get_indexed_string(&self, index: i32) -> HidResult<String> {
+    pub fn get_indexed_string(&self, index: i32) -> HidResult<Option<String>> {
         let mut buf = [0 as wchar_t; STRING_BUF_LEN];
         let res = unsafe {
-            ffi::hid_get_indexed_string(self._hid_device,
-                                        index as c_int,
-                                        buf.as_mut_ptr(),
-                                        STRING_BUF_LEN)
+            ffi::hid_get_indexed_string(
+                self._hid_device,
+                index as c_int,
+                buf.as_mut_ptr(),
+                STRING_BUF_LEN,
+            )
         };
-        let res = try!(self.check_size(res));
+        let res = self.check_size(res)?;
         unsafe { wchar_to_string(buf[..res].as_ptr()) }
     }
 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -101,7 +101,9 @@ pub struct HidApi {
 static mut HID_API_LOCK: bool = false;
 
 impl HidApi {
-    /// Initializes the HID
+    /// Initializes the hidapi.
+    ///
+    /// Will also initialize the currently available device list.
     pub fn new() -> HidResult<Self> {
         let lock = HidApiLock::acquire()?;
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -132,7 +132,9 @@ impl HidApi {
     /// Open a HID device using a Vendor ID (VID), Product ID (PID) and
     /// a serial number.
     pub fn open_serial(&self, vid: u16, pid: u16, sn: &str) -> HidResult<HidDevice> {
-        let device = unsafe { ffi::hid_open(vid, pid, std::mem::transmute(sn.as_ptr())) };
+        let mut chars = sn.chars().map(|c| c as wchar_t).collect::<Vec<_>>();
+        chars.push(0 as wchar_t);
+        let device = unsafe { ffi::hid_open(vid, pid, chars.as_ptr()) };
         if device.is_null() {
             Err("Unable to open hid device")
         } else {


### PR DESCRIPTION
**Edit: this PR contains many more changes, and is here to trick github.**



Hi,

I recently hit a API limitation of the library, which turned out to be a real pain in the ***.

To be more specific I came into the situation, where I absolutely had to capture an open hid device by a closure with static lifetime bounds (handler of a gtk-rs button click event).

I could not figure out any way to handle this, and so I propose this patch to the library, which should be backwards compatible (except by one thing which I will go through later). The advantage of it is the much greater flexibility with handling devices and the api, without having to worry about the lifetime constraints.

For example you now can:

* Store both a device, and the API, which spawned it inside the same struct
* Return the device from a function exceeding the lifetime of the API context
* Capture devices and the API by closures with static lifetime bounds
* Being able to elegantly use it in conjunction with gtk-rs ;-P

It is implemented, by replacing the PhantomData marker inside the devices, which ensured the lifetime bound to the API, by a new mechanism, which introduces a refcounter to the global hidapi ffi context.

It is just a new HidApiLock struct with a special constructor, and a Drop impl, which releases and acquires the global API lock.
This struct is injected inside devices and the HidApi context with a Rc smartpointer.
To make sure droporder is guaranteed under any condition, devices use a ManuallyDrop smart pointer, which makes sure the device itself gets dropped before the global API context lock.

And yes, I also did a little bit of dependency updating in my fork, I hope that is ok for you.

Edit:
The "one thing", which I forgot is, that HidDevice<'a> is now just HidDevice, which has to be adapted in cases, where the struct was used inside another struct from the library user. This should anyways be trivial.