### PR TITLE
Use hidraw instead of libusb backend on Linux

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -14,6 +14,12 @@ build = "build.rs"
 links = "hidapi"
 documentation = "https://docs.rs/hidapi"
 
+[features]
+# Enable this feature to use hidraw backend instead of
+# libusb-1.0 on Linux. Enabling this feature does not
+# affect other platforms.
+linux-hidraw = []
+
 [dependencies]
 libc = "0.2.15"
 

--- a/README.md
+++ b/README.md
@@ -13,6 +13,18 @@ used by adding `hidapi` to the dependencies in your project's `Cargo.toml`.
 [dependencies]
 hidapi = "0.3"
 ```
+
+On Linux you can choose between two hidapi backends: `libusb-1.0` or `hidraw`.
+`libusb-1.0` backend in selected by default. If you want to use `hidraw` backend
+enable `linux-hidraw` feature like this:
+
+```toml
+[dependencies]
+hidapi = {version="*", features=["linux-hidraw"]}
+```
+
+
+
 # Example
 
 ```rust

--- a/build.rs
+++ b/build.rs
@@ -24,11 +24,23 @@ fn main() {
     compile();
 }
 
-#[cfg(target_os = "linux")]
+
+#[cfg(all(target_os = "linux", not(feature="linux-hidraw")))]
 fn compile() {
     let mut config = gcc::Config::new();
     config.file("etc/hidapi/libusb/hid.c").include("etc/hidapi/hidapi");
     let lib = pkg_config::find_library("libusb-1.0").expect("Unable to find libusb-1.0");
+    for path in lib.include_paths {
+        config.include(path.to_str().expect("Failed to convert include path to str"));
+    }
+    config.compile("libhidapi.a");
+}
+
+#[cfg(all(target_os = "linux", feature="linux-hidraw"))]
+fn compile() {
+    let mut config = gcc::Config::new();
+    config.file("etc/hidapi/linux/hid.c").include("etc/hidapi/hidapi");
+    let lib = pkg_config::find_library("libudev").expect("Unable to find libudev");
     for path in lib.include_paths {
         config.include(path.to_str().expect("Failed to convert include path to str"));
     }


### PR DESCRIPTION
While testing hidapi-rs on Ubuntu I found that:
 - I need to run software as a superuser to be able to connect to devices
 - After my application exists computer stops responding to keyboard and mouse if I connect to them through hidapi-rs

After a bit of research I found that libusb implementation of hidapi disconnects kernel's hidraw driver when opening a HID device. Additionally it is not possible to access HID devices connected through Bluetooth. Switching to hidraw backend for hidapi fixes issues mentioned above.