### PR TITLE
allow usage of hidapi shared libs

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -14,6 +14,11 @@ build = "build.rs"
 links = "hidapi"
 documentation = "https://docs.rs/hidapi"
 
+[features]
+default = []
+shared-libusb = []
+shared-hidraw = []
+
 [dependencies]
 libc = "0.2.15"
 

--- a/build.rs
+++ b/build.rs
@@ -24,7 +24,7 @@ fn main() {
     compile();
 }
 
-#[cfg(target_os = "linux")]
+#[cfg(all(target_os = "linux", not(any(feature = "shared-libusb", feature = "shared-hidraw"))))]
 fn compile() {
     let mut config = gcc::Config::new();
     config.file("etc/hidapi/libusb/hid.c").include("etc/hidapi/hidapi");
@@ -33,6 +33,16 @@ fn compile() {
         config.include(path.to_str().expect("Failed to convert include path to str"));
     }
     config.compile("libhidapi.a");
+}
+
+#[cfg(all(target_os = "linux", feature = "shared-libusb", not(feature = "shared-hidraw")))]
+fn compile() {
+    pkg_config::probe_library("hidapi-libusb").expect("Unable to find hidapi-libusb");
+}
+
+#[cfg(all(target_os = "linux", feature = "shared-hidraw"))]
+fn compile() {
+    pkg_config::probe_library("hidapi-hidraw").expect("Unable to find hidapi-hidraw");
 }
 
 #[cfg(target_os = "windows")]


### PR DESCRIPTION
This makes it possible to use libhidapi-libusb.so or libhidapi-hidraw.so on Linux rather than statically linking hidapi. This will save some space and make it possible to upgrade the hidapi library independently of the app. I'm using this on a small embedded system, so the space is actually relevant for me. 
I don't have any macOS or Windows machines to test it on, so it's limited to Linux for now. The feature can be enabled by building with `cargo build --features=shared-hidraw` or `--features=shared-libusb`. If no feature flags are specified, you get the old behaviour. If both are specified, `libhidapi-hidraw` is used (this is primarily to allow usage of `--all-features`).

