### PR TITLE
Fix incorrect compare_and_swap check

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -52,7 +52,9 @@ use std::rc::Rc;
 use std::sync::atomic::{AtomicBool, Ordering};
 
 pub use error::HidError;
+
 pub type HidResult<T> = Result<T, HidError>;
+
 const STRING_BUF_LEN: usize = 128;
 
 /// Hidapi context and device member, which ensures deinitialization
@@ -61,7 +63,12 @@ struct HidApiLock;
 
 impl HidApiLock {
     fn acquire() -> HidResult<HidApiLock> {
-        if HID_API_LOCK.compare_and_swap(false, true, Ordering::SeqCst) {
+        const EXPECTED_CURRENT: bool = false;
+
+        if EXPECTED_CURRENT == HID_API_LOCK.compare_and_swap(EXPECTED_CURRENT,
+                                                             true,
+                                                             Ordering::SeqCst) {
+
             // Initialize the HID and prevent other HIDs from being created
             unsafe {
                 if ffi::hid_init() == -1 {


### PR DESCRIPTION
At the moment (v0.5.1) valid calls to `acquire` fail. Any application using this library will fail to acquire an API handle.

`compare_and_swap` returns the previous value so in this case a valid lock results into an `InitializationError`
