### PR TITLE
Made HidApi struct thread-safe

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -31,3 +31,6 @@ failure_derive = "0.1.2"
 [build-dependencies]
 cc = "1.0.3"
 pkg-config = "0.3.9"
+
+[dev-dependencies]
+threadgroup = "0.1.0"

--- a/examples/concurrency_test.rs
+++ b/examples/concurrency_test.rs
@@ -1,0 +1,97 @@
+extern crate hidapi;
+extern crate threadgroup;
+extern crate core;
+
+use hidapi::{HidApi, HidResult};
+use std::sync::{Arc, Mutex};
+use std::thread;
+
+struct AnotherTestThing;
+
+impl AnotherTestThing{
+    fn do_something(test_thing: Arc<TestThing>){
+        thread::spawn(move || {
+            let test_clone1 = Arc::clone(&test_thing);
+            let thread1 = thread::Builder::new().name("thread1".to_string()).spawn(move || {
+                let hidapi = Mutex::lock(&test_clone1.hidapi).unwrap();
+                let id = thread::current().id();
+                println!("[{:?}]: Printing devices in separate thread:", id);
+                for d in hidapi.devices() {
+                    let dclone = &d.clone();
+                    let product_string = dclone.product_string.clone();
+                    let man_string = dclone.manufacturer_string.clone();
+                    println!("[{:?}]: ---------------------", id);
+                    println!("[{:?}]: vid: {:?}", id, dclone.vendor_id);
+                    println!("[{:?}]: pid: {:?}", id, dclone.product_id);
+                    println!("[{:?}]: prod_str: {:?}", id, &product_string.expect("Could not unwrap product_string"));
+                    println!("[{:?}]: man_str: {:?}", id, &man_string.unwrap());
+                    println!("[{:?}]: Opening device...", id);
+                    let res = dclone.open_device(&hidapi);
+                    match res {
+                        Ok(d) => {
+                            println!("[{:?}]: Successfully opened device: {:?}", id, d.get_product_string().unwrap());
+                        },
+                        Err(e) => {
+                            eprintln!("[{:?}]: Could not opened device; continuing anyways!", id);
+                            eprintln!("[{:?}]:\tError: {}", id, e);
+                        }
+                    }
+                }
+            }).unwrap();
+            let test_clone2 = Arc::clone(&test_thing);
+            let thread2 = thread::Builder::new().name("thread2".to_string()).spawn(move || {
+                let hidapi = Mutex::lock(&test_clone2.hidapi).unwrap();
+                let id = thread::current().id();
+                println!("[{:?}]: Printing devices in separate thread:", id);
+                for d in hidapi.devices() {
+                    let dclone = &d.clone();
+                    let product_string = dclone.product_string.clone();
+                    let man_string = dclone.manufacturer_string.clone();
+                    println!("[{:?}]: ---------------------", id);
+                    println!("[{:?}]: vid: {:?}", id, dclone.vendor_id);
+                    println!("[{:?}]: pid: {:?}", id, dclone.product_id);
+                    println!("[{:?}]: prod_str: {:?}", id, &product_string.expect("Could not unwrap product_string"));
+                    println!("[{:?}]: man_str: {:?}", id, &man_string.unwrap());
+                    println!("[{:?}]: Opening device...", id);
+                    let res = dclone.open_device(&hidapi);
+                    match res {
+                        Ok(d) => {
+                            println!("[{:?}]: Successfully opened device: {:?}", id, d.get_product_string().unwrap());
+                        },
+                        Err(e) => {
+                            eprintln!("[{:?}]: Could not opened device; continuing anyways!", id);
+                            eprintln!("[{:?}]:\tError: {}", id, e);
+                        }
+                    }
+                }
+            }).unwrap();
+            thread1.join().unwrap();
+            thread2.join().unwrap();
+        }).join().unwrap();
+    }
+}
+
+struct TestThing{
+    hidapi: Arc<Mutex<HidApi>>
+}
+
+impl TestThing{
+    pub fn new() -> Option<TestThing>{
+        let _hidapi = HidApi::new();
+        match _hidapi{
+            Ok(h) => {
+                let harc = Arc::new(Mutex::new(h));
+                Some(TestThing{ hidapi: harc })
+            },
+            Err(e) => {
+                eprintln!("Error: {}", e);
+                None
+            }
+        }
+    }
+}
+
+fn main(){
+    let test_thing = Arc::new(TestThing::new().unwrap());
+    AnotherTestThing::do_something(test_thing);
+}

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -48,10 +48,10 @@ use libc::{c_int, size_t, wchar_t};
 use std::ffi::CStr;
 use std::ffi::CString;
 use std::mem::ManuallyDrop;
-use std::rc::Rc;
 use std::sync::atomic::{AtomicBool, Ordering};
 
 pub use error::HidError;
+use std::sync::Arc;
 
 pub type HidResult<T> = Result<T, HidError>;
 
@@ -94,7 +94,7 @@ impl Drop for HidApiLock {
 /// Only one instance can exist at a time.
 pub struct HidApi {
     devices: Vec<HidDeviceInfo>,
-    _lock: Rc<HidApiLock>,
+    _lock: Arc<HidApiLock>,
 }
 
 static HID_API_LOCK: AtomicBool = AtomicBool::new(false);
@@ -108,7 +108,7 @@ impl HidApi {
 
         Ok(HidApi {
             devices: unsafe { HidApi::get_hid_device_info_vector()? },
-            _lock: Rc::new(lock),
+            _lock: Arc::new(lock),
         })
     }
 
@@ -279,7 +279,7 @@ impl HidDeviceInfo {
 pub struct HidDevice {
     _hid_device: *mut ffi::HidDevice,
     /// Prevents this from outliving the api instance that created it
-    _lock: ManuallyDrop<Rc<HidApiLock>>,
+    _lock: ManuallyDrop<Arc<HidApiLock>>,
 }
 
 impl Drop for HidDevice {


### PR DESCRIPTION
I ran into a problem where I had different threads trying to reference my program's HidApi instance. However, HidApi was not thread-safe due to the _lock field being a non-async reference counted HidApiLock `Rc<HidApiLock>`. I changed this to be `Arc<HidApiLock>`, that way multiple threads can reference the hidapi instance. I provided a really crappy example of it working.

I know the underlying lower level implications of this that this could allow dependents to write to a HidDevice from multiple threads but I think that we cannot control that due to the fact that this relies on the C implementation of hidapi as the backend. I see that there is currently plans for isolating this library into its own pure rust implementation and I believe that would make way for a more thread-safe implementation of this library unless we can do some kind of hacky write access block if the device is currently already being written to in the write binding. I haven't completely explored this yet but I honestly just needed a _simple_ way of allowing multiple threads to reference my hidapi instance. My project's implementation is simply just a single thread for reading and a single thread for writing. This is the fix that I came up with.

I know the example is very bad and I couldn't demonstrate multiple device opens in parallel but it seems to be just fine. And that's another thing that could be dangerous: multiple threads opening a device concurrently. The point is, I made this library just a tiny bit more thread-safe while also introducing some possible hazards. But it's a fix for now I guess.