### PR TITLE
Allow HidDevice to be sent across threads

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -48,7 +48,7 @@ use libc::{c_int, size_t, wchar_t};
 use std::ffi::CStr;
 use std::ffi::CString;
 use std::mem::ManuallyDrop;
-use std::rc::Rc;
+use std::sync::Arc;
 use std::sync::atomic::{AtomicBool, Ordering};
 
 pub use error::HidError;
@@ -94,7 +94,7 @@ impl Drop for HidApiLock {
 /// Only one instance can exist at a time.
 pub struct HidApi {
     devices: Vec<HidDeviceInfo>,
-    _lock: Rc<HidApiLock>,
+    _lock: Arc<HidApiLock>,
 }
 
 static HID_API_LOCK: AtomicBool = AtomicBool::new(false);
@@ -108,7 +108,7 @@ impl HidApi {
 
         Ok(HidApi {
             devices: unsafe { HidApi::get_hid_device_info_vector()? },
-            _lock: Rc::new(lock),
+            _lock: Arc::new(lock),
         })
     }
 
@@ -279,8 +279,10 @@ impl HidDeviceInfo {
 pub struct HidDevice {
     _hid_device: *mut ffi::HidDevice,
     /// Prevents this from outliving the api instance that created it
-    _lock: ManuallyDrop<Rc<HidApiLock>>,
+    _lock: ManuallyDrop<Arc<HidApiLock>>,
 }
+
+unsafe impl Send for HidDevice {}
 
 impl Drop for HidDevice {
     fn drop(&mut self) {


### PR DESCRIPTION
As far as I can tell this is safe (despite the empty `unsafe` impl for `Send`), since it's still using the lock to control API access.

This provides a really nice usability boost for me as I can integrate hidapi with rocket for making web interfaces for devices.