### PR TITLE
Update hidapi to use libusb fork

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1,3 +1,3 @@
 [submodule "etc/hidapi"]
 	path = etc/hidapi
-	url = https://github.com/signal11/hidapi.git
+	url = https://github.com/libusb/hidapi.git


### PR DESCRIPTION
- signal11 repo has not been maintained since 2016
- See Issue #46