### PR TITLE
Do not fail on wchar_t* to string conversion

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "hidapi"
-version = "1.1.1"
+version = "1.2.0"
 authors = [
     "Roland Ruckerbauer <roland.rucky@gmail.com>",
     "Osspial <osspial@gmail.com>",

--- a/examples/lshid.rs
+++ b/examples/lshid.rs
@@ -17,10 +17,14 @@ fn main() {
         Ok(api) => {
             for device in api.device_list() {
                 println!(
-                    "VID: {:04x}, PID: {:04x}, Serial: {}",
+                    "VID: {:04x}, PID: {:04x}, Serial: {}, Product name: {}",
                     device.vendor_id(),
                     device.product_id(),
                     match device.serial_number() {
+                        Some(s) => s,
+                        _ => "<COULD NOT FETCH>",
+                    },
+                    match device.product_string() {
                         Some(s) => s,
                         _ => "<COULD NOT FETCH>",
                     }

--- a/examples/lshid.rs
+++ b/examples/lshid.rs
@@ -15,8 +15,16 @@ fn main() {
 
     match HidApi::new() {
         Ok(api) => {
-            for device in api.devices() {
-                println!("{:#?}", device);
+            for device in api.device_list() {
+                println!(
+                    "VID: {:04x}, PID: {:04x}, Serial: {}",
+                    device.vendor_id(),
+                    device.product_id(),
+                    match device.serial_number() {
+                        Some(s) => s,
+                        _ => "<COULD NOT FETCH>",
+                    }
+                );
             }
         }
         Err(e) => {

--- a/examples/open_first_device.rs
+++ b/examples/open_first_device.rs
@@ -16,13 +16,12 @@ fn main() {
         let hidapi = HidApi::new()?;
 
         let device_info = hidapi
-            .devices()
-            .iter()
+            .device_list()
             .next()
             .expect("No devices are available!")
             .clone();
 
-        println!("Opening device:\n {:#?}\n", device_info);
+        println!("Opening device:\n VID: {:04x}, PID: {:04x}\n", device_info.vendor_id(), device_info.product_id());
 
         let device = device_info.open_device(&hidapi)?;
 

--- a/examples/static_lifetime_bound.rs
+++ b/examples/static_lifetime_bound.rs
@@ -23,16 +23,14 @@ fn requires_static_lt_bound<F: Fn() + 'static>(f: F) {
 fn test_lt() -> Rc<HidDevice> {
     let api = HidApi::new().expect("Hidapi init failed");
 
-    let devices = api.devices();
+    let mut devices = api.device_list();
 
     let dev_info = devices
-        .get(0)
+        .nth(0)
         .expect("There is not a single hid device available");
 
-    println!("{:#?}", dev_info);
-
     let dev = Rc::new(
-        api.open(dev_info.vendor_id, dev_info.product_id)
+        api.open(dev_info.vendor_id(), dev_info.product_id())
             .expect("Can not open device"),
     );
 


### PR DESCRIPTION
Quick fix for issue #52.

Instead of failing, return None value.

Edit:

Also added new DeviceInfo with access to raw wchar_t strings, and deprecated HidDeviceInfo and friends.