### PR TITLE
macos: fix build by linking to AppKit for NSAppKitVersionNumber symbol

### DIFF
--- a/build.rs
+++ b/build.rs
@@ -127,4 +127,5 @@ fn compile_macos() {
         .compile("libhidapi.a");
     println!("cargo:rustc-link-lib=framework=IOKit");
     println!("cargo:rustc-link-lib=framework=CoreFoundation");
+    println!("cargo:rustc-link-lib=framework=AppKit")
 }


### PR DESCRIPTION
New hidapi checks for the macos version, which requires linking to AppKit framework. Link to AppKit to
fix linker error.