### PR TITLE
Switched to the non-deprecated function in the README example

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,7 +16,7 @@ extern crate hidapi;
 
 let api = hidapi::HidApi::new().unwrap();
 // Print out information about all connected devices
-for device in api.devices() {
+for device in api.device_list() {
     println!("{:#?}", device);
 }
 


### PR DESCRIPTION
Changed to the non deprecated function in the README example.