### PR TITLE
Static CRT support

### DIFF
--- a/build.rs
+++ b/build.rs
@@ -113,12 +113,14 @@ fn compile_freebsd() {
 }
 
 fn compile_windows() {
+    let linkage = env::var("CARGO_CFG_TARGET_FEATURE").unwrap_or(String::new());
+
     let mut cc = cc::Build::new();
     cc
         .file("etc/hidapi/windows/hid.c")
         .include("etc/hidapi/hidapi");
 
-    if cfg!(target_feature = "crt-static") {
+    if linkage.contains("crt-static") {
         // https://doc.rust-lang.org/reference/linkage.html#static-and-dynamic-c-runtimes
         cc.static_crt(true);
     }

--- a/build.rs
+++ b/build.rs
@@ -116,6 +116,7 @@ fn compile_windows() {
     cc::Build::new()
         .file("etc/hidapi/windows/hid.c")
         .include("etc/hidapi/hidapi")
+        .static_crt(true)
         .compile("libhidapi.a");
     println!("cargo:rustc-link-lib=setupapi");
 }

--- a/build.rs
+++ b/build.rs
@@ -113,11 +113,16 @@ fn compile_freebsd() {
 }
 
 fn compile_windows() {
-    cc::Build::new()
+    let mut cc = cc::Build::new();
+    cc
         .file("etc/hidapi/windows/hid.c")
-        .include("etc/hidapi/hidapi")
-        .static_crt(true)
-        .compile("libhidapi.a");
+        .include("etc/hidapi/hidapi");
+
+    if cfg!(target_feature = "crt-static") {
+        // https://doc.rust-lang.org/reference/linkage.html#static-and-dynamic-c-runtimes
+        cc.static_crt(true);
+    }
+    cc.compile("libhidapi.a");
     println!("cargo:rustc-link-lib=setupapi");
 }
 


### PR DESCRIPTION
Tested, works fine.

It builds static CRT only when required: https://doc.rust-lang.org/reference/linkage.html#static-and-dynamic-c-runtimes.

Fixes #69.