### PR TITLE
Update link in doc comment

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -5,7 +5,7 @@
 // *************************************************************************
 
 //! This crate provides a rust abstraction over the features of the C library
-//! hidapi by [signal11](https://github.com/signal11/hidapi).
+//! hidapi by [signal11](https://github.com/libusb/hidapi).
 //!
 //! # Usage
 //!


### PR DESCRIPTION
I think the signal11 repo is not maintained anymore, and the libusb one is the current one.