### PR TITLE
Retrieve error message from hidapi for general errors

### DIFF
--- a/src/error.rs
+++ b/src/error.rs
@@ -16,6 +16,7 @@ pub enum HidError {
     HidApiErrorEmpty,
     FromWideCharError { wide_char: wchar_t },
     InitializationError,
+    #[deprecated]
     OpenHidDeviceError,
     InvalidZeroSizeData,
     IncompleteSendError { sent: usize, all: usize },


### PR DESCRIPTION
The `hid_error` function can also be used when opening a device.
