### PR TITLE
update hidapi submodule to 0.11.2 and bump crate version

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "hidapi"
-version = "1.3.0"
+version = "1.3.1"
 authors = [
     "Roland Ruckerbauer <roland.rucky@gmail.com>",
     "Osspial <osspial@gmail.com>",


### PR DESCRIPTION
https://github.com/libusb/hidapi/releases/tag/hidapi-0.11.2