### PR TITLE
Add OpenBSD to supported platforms

### DIFF
--- a/build.rs
+++ b/build.rs
@@ -33,7 +33,9 @@ fn main() {
         compile_macos();
     } else if target.contains("freebsd") {
         compile_freebsd();
-    } else if target.contains("illumos") {
+    } else if target.contains("openbsd") {
+        compile_openbsd();
+     } else if target.contains("illumos") {
         compile_illumos();
     } else {
         panic!("Unsupported target os for hidapi-rs");
@@ -112,6 +114,10 @@ fn compile_linux() {
 
 fn compile_freebsd() {
     pkg_config::probe_library("hidapi").expect("Unable to find hidapi");
+}
+
+fn compile_openbsd() {
+    pkg_config::probe_library("hidapi-libusb").expect("Unable to find hidapi");
 }
 
 fn compile_illumos() {

--- a/src/ffi.rs
+++ b/src/ffi.rs
@@ -25,7 +25,10 @@ pub struct HidDeviceInfo {
 
 #[allow(dead_code)]
 extern "C" {
+    #[cfg(not(target_os = "openbsd"))]
     pub fn hid_init() -> c_int;
+    #[cfg(target_os = "openbsd")]
+    pub fn hidapi_hid_init() -> c_int;
     pub fn hid_exit() -> c_int;
     pub fn hid_enumerate(vendor_id: c_ushort, product_id: c_ushort) -> *mut HidDeviceInfo;
     pub fn hid_free_enumeration(hid_device_info: *mut HidDeviceInfo);

--- a/src/ffi.rs
+++ b/src/ffi.rs
@@ -25,10 +25,8 @@ pub struct HidDeviceInfo {
 
 #[allow(dead_code)]
 extern "C" {
-    #[cfg(not(target_os = "openbsd"))]
+    #[cfg_attr(target_os = "openbsd", link_name = "hidapi_hid_init")]
     pub fn hid_init() -> c_int;
-    #[cfg(target_os = "openbsd")]
-    pub fn hidapi_hid_init() -> c_int;
     pub fn hid_exit() -> c_int;
     pub fn hid_enumerate(vendor_id: c_ushort, product_id: c_ushort) -> *mut HidDeviceInfo;
     pub fn hid_free_enumeration(hid_device_info: *mut HidDeviceInfo);

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -70,6 +70,12 @@ impl HidApiLock {
         {
             // Initialize the HID and prevent other HIDs from being created
             unsafe {
+                #[cfg(target_os = "openbsd")]
+                if ffi::hidapi_hid_init() == -1 {
+                    HID_API_LOCK.store(false, Ordering::SeqCst);
+                    return Err(HidError::InitializationError);
+                }
+                #[cfg(not(target_os = "openbsd"))]
                 if ffi::hid_init() == -1 {
                     HID_API_LOCK.store(false, Ordering::SeqCst);
                     return Err(HidError::InitializationError);

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -70,12 +70,6 @@ impl HidApiLock {
         {
             // Initialize the HID and prevent other HIDs from being created
             unsafe {
-                #[cfg(target_os = "openbsd")]
-                if ffi::hidapi_hid_init() == -1 {
-                    HID_API_LOCK.store(false, Ordering::SeqCst);
-                    return Err(HidError::InitializationError);
-                }
-                #[cfg(not(target_os = "openbsd"))]
                 if ffi::hid_init() == -1 {
                     HID_API_LOCK.store(false, Ordering::SeqCst);
                     return Err(HidError::InitializationError);


### PR DESCRIPTION
This PR adds OpenBSD to the supported platforms. 

Unfortunately hidapi's `hid_init()` needed to be renamed to `hidapi_hid_init()` on OpenBSD due to a naming conflict with a system library function, so we need to work around that, too. I still hope you'll consider it for inclusion.