### PR TITLE
Implement MacOS and Windows APIs from `hidapi` 0.12 release

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -7,6 +7,7 @@ authors = [
     "Artyom Pavlov <newpavlov@gmail.com>",
     "mberndt123",
     "niklasad1",
+    "Stefan Kerkmann"
 ]
 repository = "https://github.com/ruabmbua/hidapi-rs"
 description = "Rust-y wrapper around hidapi"
@@ -24,6 +25,7 @@ linux-shared-libusb = []
 linux-shared-hidraw = []
 illumos-static-libusb = []
 illumos-shared-libusb = []
+macos-shared-device = []
 
 [dependencies]
 libc = "0.2"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -36,3 +36,6 @@ winapi = "0.3.9"
 [build-dependencies]
 cc = "1.0"
 pkg-config = "0.3"
+
+[package.metadata.docs.rs]
+rustdoc-args = ["--cfg", "docsrs"]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -5,13 +5,13 @@ authors = [
     "Roland Ruckerbauer <roland.rucky@gmail.com>",
     "Osspial <osspial@gmail.com>",
     "Artyom Pavlov <newpavlov@gmail.com>",
-	"mberndt123",
-	"niklasad1"
+    "mberndt123",
+    "niklasad1",
 ]
 repository = "https://github.com/ruabmbua/hidapi-rs"
 description = "Rust-y wrapper around hidapi"
 license = "MIT"
-keywords = ["hid", "api", "usb","binding", "wrapper"]
+keywords = ["hid", "api", "usb", "binding", "wrapper"]
 build = "build.rs"
 links = "hidapi"
 documentation = "https://docs.rs/hidapi"
@@ -27,6 +27,9 @@ illumos-shared-libusb = []
 
 [dependencies]
 libc = "0.2"
+
+[target.'cfg(windows)'.dependencies]
+winapi = "0.3.9"
 
 [build-dependencies]
 cc = "1.0"

--- a/build.rs
+++ b/build.rs
@@ -164,7 +164,7 @@ fn compile_illumos() {
 }
 
 fn compile_windows() {
-    let linkage = env::var("CARGO_CFG_TARGET_FEATURE").unwrap_or(String::new());
+    let linkage = env::var("CARGO_CFG_TARGET_FEATURE").unwrap_or_default();
 
     let mut cc = cc::Build::new();
     cc.file("etc/hidapi/windows/hid.c")

--- a/examples/static_lifetime_bound.rs
+++ b/examples/static_lifetime_bound.rs
@@ -25,8 +25,7 @@ fn test_lt() -> Rc<HidDevice> {
 
     let mut devices = api.device_list();
 
-    let dev_info = devices
-        .nth(0)
+    let dev_info = devices.next()
         .expect("There is not a single hid device available");
 
     let dev = Rc::new(

--- a/src/ffi.rs
+++ b/src/ffi.rs
@@ -6,6 +6,7 @@
 // For documentation look at the corresponding C header file hidapi.h
 use libc::{c_char, c_int, c_uchar, c_ushort, c_void, intptr_t, size_t, wchar_t};
 
+#[doc(hidden)]
 #[macro_export]
 macro_rules! cfg_libusb_only {
     ($i: block) => {

--- a/src/ffi.rs
+++ b/src/ffi.rs
@@ -120,3 +120,31 @@ extern "C" {
     ) -> c_int;
     pub fn hid_error(device: *mut HidDevice) -> *const wchar_t;
 }
+
+// For documentation look at the corresponding C header file hidapi_darwin.h
+#[cfg(target_os = "macos")]
+pub mod macos {
+    use super::*;
+
+    extern "C" {
+        pub fn hid_darwin_get_location_id(device: *mut HidDevice, location_id: *mut u32) -> c_int;
+        pub fn hid_darwin_set_open_exclusive(open_exclusive: c_int);
+        pub fn hid_darwin_get_open_exclusive() -> c_int;
+        pub fn hid_darwin_is_device_open_exclusive(device: *mut HidDevice) -> c_int;
+    }
+}
+
+// For documentation look at the corresponding C header file hidapi_winapi.h
+#[cfg(target_os = "windows")]
+pub mod windows {
+    use winapi::shared::guiddef::GUID;
+
+    use super::*;
+    extern "C" {
+        pub fn hid_winapi_get_container_id(
+            device: *mut HidDevice,
+            container_id: *mut GUID,
+        ) -> c_int;
+
+    }
+}

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -47,6 +47,7 @@ use libc::{c_int, size_t, wchar_t};
 use std::ffi::CStr;
 use std::ffi::CString;
 use std::fmt;
+use std::fmt::Debug;
 use std::mem::ManuallyDrop;
 use std::sync::atomic::{AtomicBool, Ordering};
 use std::sync::Arc;
@@ -539,6 +540,12 @@ pub struct HidDevice {
 }
 
 unsafe impl Send for HidDevice {}
+
+impl Debug for HidDevice {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        f.debug_struct("HidDevice").finish()
+    }
+}
 
 impl Drop for HidDevice {
     fn drop(&mut self) {

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -492,9 +492,9 @@ impl DeviceInfo {
     ///
     /// Note, that opening a device could still be done using [HidApi::open()](struct.HidApi.html#method.open) directly.
     pub fn open_device(&self, hidapi: &HidApi) -> HidResult<HidDevice> {
-        if self.path.as_bytes().len() != 0 {
+        if !self.path.as_bytes().is_empty() {
             hidapi.open_path(self.path.as_c_str())
-        } else if let Some(ref sn) = self.serial_number() {
+        } else if let Some(sn) = self.serial_number() {
             hidapi.open_serial(self.vendor_id, self.product_id, sn)
         } else {
             Err(HidError::OpenHidDeviceWithDeviceInfoError {
@@ -550,7 +550,7 @@ impl HidDeviceInfo {
     ///
     /// Note, that opening a device could still be done using [HidApi::open()](struct.HidApi.html#method.open) directly.
     pub fn open_device(&self, hidapi: &HidApi) -> HidResult<HidDevice> {
-        if self.path.as_bytes().len() != 0 {
+        if !self.path.as_bytes().is_empty() {
             hidapi.open_path(self.path.as_c_str())
         } else if let Some(ref sn) = self.serial_number {
             hidapi.open_serial(self.vendor_id, self.product_id, sn)
@@ -631,7 +631,7 @@ impl HidDevice {
     /// one exists. If it does not, it will send the data through
     /// the Control Endpoint (Endpoint 0).
     pub fn write(&self, data: &[u8]) -> HidResult<usize> {
-        if data.len() == 0 {
+        if data.is_empty() {
             return Err(HidError::InvalidZeroSizeData);
         }
         let res = unsafe { ffi::hid_write(self._hid_device, data.as_ptr(), data.len() as size_t) };
@@ -674,7 +674,7 @@ impl HidDevice {
     /// do not use numbered reports), followed by the report data (16 bytes).
     /// In this example, the length passed in would be 17.
     pub fn send_feature_report(&self, data: &[u8]) -> HidResult<()> {
-        if data.len() == 0 {
+        if data.is_empty() {
             return Err(HidError::InvalidZeroSizeData);
         }
         let res = unsafe {

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -63,8 +63,10 @@ mod error;
 mod ffi;
 
 #[cfg(target_os = "macos")]
+#[cfg_attr(docsrs, doc(cfg(target_os = "macos")))]
 mod macos;
 #[cfg(target_os = "windows")]
+#[cfg_attr(docsrs, doc(cfg(target_os = "windows")))]
 mod windows;
 
 use libc::{c_int, size_t, wchar_t};

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -35,13 +35,21 @@
 //! }
 //! ```
 
-// Allow use of deprecated items, we defined ourselfes...
+// Allow use of deprecated items, we defined ourselves...
 #![allow(deprecated)]
 
 extern crate libc;
 
+#[cfg(target_os = "windows")]
+extern crate winapi;
+
 mod error;
 mod ffi;
+
+#[cfg(target_os = "macos")]
+mod macos;
+#[cfg(target_os = "windows")]
+mod windows;
 
 use libc::{c_int, size_t, wchar_t};
 use std::ffi::CStr;
@@ -75,6 +83,7 @@ impl HidApiLock {
                     HID_API_LOCK.store(false, Ordering::SeqCst);
                     return Err(HidError::InitializationError);
                 }
+
                 Ok(HidApiLock)
             }
         } else {

--- a/src/macos.rs
+++ b/src/macos.rs
@@ -4,8 +4,6 @@ use crate::ffi;
 use crate::{HidApi, HidDevice, HidResult};
 
 impl HidApi {
-    /// **`Only available on MacOS`**
-    ///
     /// Changes the behavior of all further calls that open a new [`HidDevice`]
     /// like [`HidApi::open`] or [`HidApi::open_path`]. By default on Darwin
     /// platform all devices opened by [`HidApi`] are opened in exclusive mode.
@@ -17,8 +15,6 @@ impl HidApi {
         unsafe { ffi::macos::hid_darwin_set_open_exclusive(exclusive as c_int) }
     }
 
-    /// **`Only available on MacOS`**
-    ///
     /// Get the current opening behavior set by [`HidApi::set_open_exclusive`].
     pub fn get_open_exclusive(&self) -> bool {
         unsafe { ffi::macos::hid_darwin_get_open_exclusive() != 0 }
@@ -26,8 +22,6 @@ impl HidApi {
 }
 
 impl HidDevice {
-    /// **`Only available on MacOS`**
-    ///
     /// Get the location ID for a [`HidDevice`] device.
     pub fn get_location_id(&self) -> HidResult<u32> {
         let mut location_id: u32 = 0;
@@ -46,8 +40,6 @@ impl HidDevice {
         }
     }
 
-    /// **`Only available on MacOS`**
-    ///
     /// Check if the device was opened in exclusive mode.
     pub fn is_open_exclusive(&self) -> HidResult<bool> {
         let res = unsafe { ffi::macos::hid_darwin_is_device_open_exclusive(self._hid_device) };

--- a/src/macos.rs
+++ b/src/macos.rs
@@ -1,0 +1,64 @@
+use libc::c_int;
+
+use crate::ffi;
+use crate::{HidApi, HidDevice, HidResult};
+
+impl HidApi {
+    /// **`Only available on MacOS`**
+    ///
+    /// Changes the behavior of all further calls that open a new [`HidDevice`]
+    /// like [`HidApi::open`] or [`HidApi::open_path`]. By default on Darwin
+    /// platform all devices opened by [`HidApi`] are opened in exclusive mode.
+    ///
+    /// When `exclusive` is set to:
+    ///   * `false` - all further devices will be opened in non-exclusive mode.
+    ///   * `true` all further devices will be opened in exclusive mode.
+    pub fn set_open_exclusive(&self, exclusive: bool) {
+        unsafe { ffi::macos::hid_darwin_set_open_exclusive(exclusive as c_int) }
+    }
+
+    /// **`Only available on MacOS`**
+    ///
+    /// Get the current opening behavior set by [`HidApi::set_open_exclusive`].
+    pub fn get_open_exclusive(&self) -> bool {
+        unsafe { ffi::macos::hid_darwin_get_open_exclusive() != 0 }
+    }
+}
+
+impl HidDevice {
+    /// **`Only available on MacOS`**
+    ///
+    /// Get the location ID for a [`HidDevice`] device.
+    pub fn get_location_id(&self) -> HidResult<u32> {
+        let mut location_id: u32 = 0;
+
+        let res = unsafe {
+            ffi::macos::hid_darwin_get_location_id(self._hid_device, &mut location_id as *mut u32)
+        };
+
+        if res == -1 {
+            match self.check_error() {
+                Ok(err) => Err(err),
+                Err(err) => Err(err),
+            }
+        } else {
+            Ok(location_id)
+        }
+    }
+
+    /// **`Only available on MacOS`**
+    ///
+    /// Check if the device was opened in exclusive mode.
+    pub fn is_open_exclusive(&self) -> HidResult<bool> {
+        let res = unsafe { ffi::macos::hid_darwin_is_device_open_exclusive(self._hid_device) };
+
+        if res == -1 {
+            match self.check_error() {
+                Ok(err) => Err(err),
+                Err(err) => Err(err),
+            }
+        } else {
+            Ok(res == 1)
+        }
+    }
+}

--- a/src/windows.rs
+++ b/src/windows.rs
@@ -1,0 +1,32 @@
+use std::ptr::addr_of_mut;
+
+use winapi::shared::guiddef::GUID;
+
+use crate::ffi;
+use crate::{HidDevice, HidResult};
+
+impl HidDevice {
+    /// **`Only available on Windows`**
+    ///
+    /// Get the container ID for a HID device.
+    ///
+    /// This function returns the `DEVPKEY_Device_ContainerId` property of the
+    /// given device. This can be used to correlate different interfaces/ports
+    /// on the same hardware device.
+    pub fn get_container_id(&self) -> HidResult<GUID> {
+        let mut container_id: GUID = unsafe { std::mem::zeroed() };
+
+        let res = unsafe {
+            ffi::windows::hid_winapi_get_container_id(self._hid_device, addr_of_mut!(container_id))
+        };
+
+        if res == -1 {
+            match self.check_error() {
+                Ok(err) => Err(err),
+                Err(err) => Err(err),
+            }
+        } else {
+            Ok(container_id)
+        }
+    }
+}

--- a/src/windows.rs
+++ b/src/windows.rs
@@ -6,8 +6,6 @@ use crate::ffi;
 use crate::{HidDevice, HidResult};
 
 impl HidDevice {
-    /// **`Only available on Windows`**
-    ///
     /// Get the container ID for a HID device.
     ///
     /// This function returns the `DEVPKEY_Device_ContainerId` property of the


### PR DESCRIPTION
This PR implements FFI bindings and safe implementations for the following APIs that where added in `hidapi` release 0.12

**MacOS:**
  * `hid_darwin_get_location_id()`
  * `hid_darwin_set_open_exclusive()`
  * `hid_darwin_get_open_exclusive()`
  * `hid_darwin_is_device_open_exclusive()`
 
**Windows:**
   * `hid_winapi_get_container_id()`

The `hid_darwin_set_open_exclusive()` API is also put to use by introducing the `macos-shared-device` feature flag for MacOS so it is possible to have multiple `HidDevice` handles that access the same physical device.

A convenience addition is the implementation of `Debug` for `HidDevice`, this will only print `HidDevice` but allows wrapping types like `HidResult<HidDevice>` into a `dbg!` macro. 
