### PR TITLE
Rebuild if the hidapi file changes

### DIFF
--- a/build.rs
+++ b/build.rs
@@ -51,6 +51,7 @@ fn compile_linux() {
             "LINUX_STATIC_HIDRAW",
             Box::new(|| {
                 let mut config = cc::Build::new();
+                println!("cargo:rerun-if-changed=etc/hidapi/linux/hid.c");
                 config
                     .file("etc/hidapi/linux/hid.c")
                     .include("etc/hidapi/hidapi");
@@ -62,6 +63,7 @@ fn compile_linux() {
             "LINUX_STATIC_LIBUSB",
             Box::new(|| {
                 let mut config = cc::Build::new();
+                println!("cargo:rerun-if-changed=etc/hidapi/linux/hid.c");
                 config
                     .file("etc/hidapi/libusb/hid.c")
                     .include("etc/hidapi/hidapi");


### PR DESCRIPTION
It's a bit of an edge case but I find myself messing around with the C code and it's annoying that cargo doesn't know to recompile.

Though I expect it would also be useful if there's an update to the submodule and you're rebuilding.