### PR TITLE
Make the WcharString to Option<String> conversion into a From

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -264,9 +264,9 @@ enum WcharString {
     None,
 }
 
-impl Into<Option<String>> for WcharString {
-    fn into(self) -> Option<String> {
-        match self {
+impl From<WcharString> for Option<String> {
+    fn from(val: WcharString) -> Self {
+        match val {
             WcharString::String(s) => Some(s),
             _ => None,
         }


### PR DESCRIPTION
Clippy is being annoying about this and it's generally good practice to implement the `From` which then automatically gets us the `Into`.