### PR TITLE
Deprecate HidApi::check_error and HidDevice::check_error

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -252,6 +252,7 @@ impl HidApi {
     /// library failed. The contained [HidError](enum.HidError.html) is the cause, why no error could
     /// be fetched.
     #[cfg(hidapi)]
+    #[deprecated(since = "2.2.3", note = "use the return values from the other methods")]
     pub fn check_error(&self) -> HidResult<HidError> {
         HidApiBackend::check_error()
     }
@@ -498,6 +499,7 @@ impl HidDevice {
     /// library failed. The contained [HidError](enum.HidError.html) is the cause, why no error could
     /// be fetched.
     #[cfg(hidapi)]
+    #[deprecated(since = "2.2.3", note = "use the return values from the other methods")]
     pub fn check_error(&self) -> HidResult<HidError> {
         self.inner.check_error()
     }


### PR DESCRIPTION
We already provide these errors via the return values of the rest of the methods, and this is not how every backend is going to work.

Thus deprecate this C style artifact.

---

This feels like the right thing to do regardless of having a native backend as the Rust calls are doing the checking for you. I put in what is presumably the next release in `since` but that's just for display.