### PR TITLE
Fix freebsd build

### DIFF
--- a/src/ffi.rs
+++ b/src/ffi.rs
@@ -42,7 +42,7 @@ extern "C" {
     pub fn hid_open_path(path: *const c_char) -> *mut HidDevice;
     #[cfg(libusb)]
     pub fn hid_libusb_wrap_sys_device(sys_dev: intptr_t, interface_num: c_int) -> *mut HidDevice;
-    #[cfg(libusb)]
+    #[cfg(all(libusb, not(target_os = "freebsd")))]
     pub fn libusb_set_option(ctx: *mut LibusbContext, option: c_int);
     pub fn hid_write(device: *mut HidDevice, data: *const c_uchar, length: size_t) -> c_int;
     pub fn hid_read_timeout(

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -111,7 +111,7 @@ fn lazy_init(do_enumerate: bool) -> HidResult<()> {
 
     match *init_state {
         InitState::NotInit => {
-            #[cfg(libusb)]
+            #[cfg(all(libusb, not(target_os = "freebsd")))]
             if !do_enumerate {
                 // Do not scan for devices in libusb_init()
                 // Must be set before calling it.


### PR DESCRIPTION
Fixes https://github.com/ruabmbua/hidapi-rs/issues/113

libusb version of freebsd is too old and does not support libusb_set_option().
