### PR TITLE
Implement Debug for HidDevice

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -482,6 +482,12 @@ pub struct HidDevice {
     inner: Box<dyn HidDeviceBackend>,
 }
 
+impl Debug for HidDevice {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        f.debug_struct("HidDevice").finish_non_exhaustive()
+    }
+}
+
 impl HidDevice {
     fn from_backend(inner: Box<dyn HidDeviceBackend>) -> Self {
         Self { inner }


### PR DESCRIPTION
HidDevice previously implemented Debug (see
ed7bc23ea9d47e1f98e9394e3c478580a68df215), but the copy of the public API added in 7439af69b91164a70b3d1b54a6f5c6d54ebe7749 did not. This restores that functionality.

This just prints `HidDevice { .. }`, but that is still useful as it makes it easy for wrapping types to implement Debug (it makes `derive(Debug)` on structs containing a HidDevice work).