### PR TITLE
Add support for get_report_descriptor()

### DIFF
--- a/src/ffi.rs
+++ b/src/ffi.rs
@@ -86,6 +86,11 @@ extern "C" {
         string: *mut wchar_t,
         maxlen: size_t,
     ) -> c_int;
+    pub fn hid_get_report_descriptor(
+        hid_device: *mut HidDevice,
+        buf: *mut c_uchar,
+        buf_size: size_t,
+    ) -> c_int;
     pub fn hid_error(device: *mut HidDevice) -> *const wchar_t;
 }
 

--- a/src/hidapi.rs
+++ b/src/hidapi.rs
@@ -330,4 +330,11 @@ impl HidDeviceBackendBase for HidDevice {
 
         unsafe { conv_hid_device_info(raw_device) }
     }
+
+    fn get_report_descriptor(&self, buf: &mut [u8]) -> HidResult<usize> {
+        let res = unsafe {
+            ffi::hid_get_report_descriptor(self._hid_device, buf.as_mut_ptr(), buf.len())
+        };
+        self.check_size(res)
+    }
 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -97,6 +97,7 @@ use crate::hidapi::HidApiBackend;
 use linux_native::HidApiBackend;
 
 pub type HidResult<T> = Result<T, HidError>;
+pub const MAX_REPORT_DESCRIPTOR_SIZE: usize = 4096;
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 enum InitState {
@@ -434,6 +435,7 @@ trait HidDeviceBackendBase {
     fn get_manufacturer_string(&self) -> HidResult<Option<String>>;
     fn get_product_string(&self) -> HidResult<Option<String>>;
     fn get_serial_number_string(&self) -> HidResult<Option<String>>;
+    fn get_report_descriptor(&self, buf: &mut [u8]) -> HidResult<usize>;
 
     fn get_indexed_string(&self, _index: i32) -> HidResult<Option<String>> {
         Err(HidError::HidApiError {
@@ -589,6 +591,14 @@ impl HidDevice {
     /// Get a string from a HID device, based on its string index.
     pub fn get_indexed_string(&self, index: i32) -> HidResult<Option<String>> {
         self.inner.get_indexed_string(index)
+    }
+
+    /// Get a report descriptor from a HID device
+    ///
+    /// User has to provide a preallocated buffer where the descriptor will be copied to.
+    /// It is recommended to use a preallocated buffer of [`MAX_REPORT_DESCRIPTOR_SIZE`] size.
+    pub fn get_report_descriptor(&self, buf: &mut [u8]) -> HidResult<usize> {
+        self.inner.get_report_descriptor(buf)
     }
 
     /// Get [`DeviceInfo`] from a HID device.

--- a/src/linux_native.rs
+++ b/src/linux_native.rs
@@ -591,6 +591,16 @@ impl HidDeviceBackendBase for HidDevice {
             }),
         }
     }
+
+    fn get_report_descriptor(&self, buf: &mut [u8]) -> HidResult<usize> {
+        let devnum = fstat(self.fd.as_raw_fd())?.st_rdev;
+        let syspath: PathBuf = format!("/sys/dev/char/{}:{}", major(devnum), minor(devnum)).into();
+
+        let descriptor = HidrawReportDescriptor::from_syspath(&syspath)?;
+        let min_size = buf.len().min(descriptor.0.len());
+        buf[..min_size].copy_from_slice(&descriptor.0[..min_size]);
+        Ok(min_size)
+    }
 }
 
 #[cfg(test)]


### PR DESCRIPTION
Fixes #104.

Successfully tested on Windows, macOS and with the following Linux backends:

* linux-shared-hidraw
* linux-static-hidraw
* linux-native

Fails with the following Linux backends:

* linux-shared-libusb
* linux-static-libusb

(Both return `hid_error is not implemented yet` when calling `HidApi::open`.)

I haven't tested it on Illumos.