### PR TITLE
Extend CI/CD to all Linux combinations + macOS + Windows

### DIFF
--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -87,3 +87,18 @@ jobs:
       run: cargo build --no-default-features --verbose
     - name: Run tests
       run: cargo test --no-default-features --verbose
+
+  build-macos:
+    runs-on: macos-latest
+    steps:
+    - name: checkout repository and submodules
+      uses: actions/checkout@v2
+      with:
+        submodules: recursive
+    - name: Install rust environment
+      run: |
+        curl --proto '=https' --tlsv1.2 -sSf https://sh.rustup.rs | sh -s -- -y
+    - name: Build
+      run: cargo build --no-default-features --verbose
+    - name: Run tests
+      run: cargo test --no-default-features --verbose

--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -71,3 +71,19 @@ jobs:
       run: cargo build --no-default-features --features linux-native --verbose
     - name: Run tests
       run: cargo test --no-default-features --features linux-native --verbose
+
+  build-windows:
+    runs-on: windows-latest
+    steps:
+    - name: checkout repository and submodules
+      uses: actions/checkout@v2
+      with:
+        submodules: recursive
+    - name: Install rust environment
+      run: |
+        curl.exe --proto "=https" --tlsv1.2 -L -o rustup-init.exe https://static.rust-lang.org/rustup/dist/x86_64-pc-windows-msvc/rustup-init.exe
+        .\rustup-init.exe -y
+    - name: Build
+      run: cargo build --no-default-features --verbose
+    - name: Run tests
+      run: cargo test --no-default-features --verbose

--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -14,6 +14,9 @@ jobs:
 
     runs-on: ubuntu-latest
 
+    env:
+      DEBIAN_FRONTEND: noninteractive
+
     strategy:
       fail-fast: false # don't give up on the whole matrix if one variant fails
       matrix:
@@ -53,6 +56,8 @@ jobs:
 
   build-linux-native:
     runs-on: ubuntu-latest
+    env:
+      DEBIAN_FRONTEND: noninteractive
     steps:
     - name: checkout repository and submodules
       uses: actions/checkout@v2

--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -10,10 +10,49 @@ env:
   CARGO_TERM_COLOR: always
 
 jobs:
-  build:
+  build-linux:
 
     runs-on: ubuntu-latest
 
+    strategy:
+      fail-fast: false # don't give up on the whole matrix if one variant fails
+      matrix:
+        linkage: ["static", "shared"]
+        library: ["hidraw", "libusb"]
+
+    steps:
+    - name: checkout repository and submodules
+      uses: actions/checkout@v2
+      with:
+        submodules: recursive
+    - name: Install dependencies
+      run: |
+        sudo apt-get update -y
+        sudo apt-get install -y cmake libudev-dev libumockdev-dev umockdev
+    - name: Build libusb
+      run: |
+        git clone https://github.com/libusb/libusb.git ./etc/libusb/
+        cd ./etc/libusb/
+        ./autogen.sh
+        make
+        sudo make install
+    - name: Build hidapi
+      run: |
+        cd ./etc/hidapi/
+        mkdir ./build/
+        cd ./build/
+        cmake ..
+        make
+        sudo make install
+    - name: List pkgconfig definitions
+      run: grep -RHn ^ /usr/local/lib/pkgconfig
+    - name: Build
+      run: cargo build --no-default-features --features linux-${{ matrix.linkage }}-${{ matrix.library }} --verbose
+    - name: Run tests
+      run: cargo test --no-default-features --features linux-${{ matrix.linkage }}-${{ matrix.library }} --verbose
+
+  build-linux-native:
+    runs-on: ubuntu-latest
     steps:
     - name: checkout repository and submodules
       uses: actions/checkout@v2
@@ -24,6 +63,6 @@ jobs:
         sudo apt-get update -y
         sudo apt-get install -y libudev-dev
     - name: Build
-      run: cargo build --no-default-features --features linux-static-hidraw --verbose
+      run: cargo build --no-default-features --features linux-native --verbose
     - name: Run tests
-      run: cargo test --no-default-features --features linux-static-hidraw --verbose
+      run: cargo test --no-default-features --features linux-native --verbose

--- a/build.rs
+++ b/build.rs
@@ -91,6 +91,7 @@ fn compile_linux() {
         (
             "LINUX_SHARED_LIBUSB",
             Box::new(|| {
+                pkg_config::probe_library("libusb-1.0").expect("Unable to find libusb-1.0");
                 pkg_config::probe_library("hidapi-libusb").expect("Unable to find hidapi-libusb");
                 println!("cargo:rustc-cfg=libusb");
                 println!("cargo:rustc-cfg=hidapi");


### PR DESCRIPTION
Sure, it's not a test suite (kinda hard to do that without some emulation of HID hardware), but at least it should catch build issues.