### PR TITLE
Add HidApi::reset_devices & HidApi::add_devices

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "hidapi"
-version = "2.4.1"
+version = "2.5.0"
 authors = [
     "Roland Ruckerbauer <roland.rucky@gmail.com>",
     "Osspial <osspial@gmail.com>",

--- a/src/hidapi.rs
+++ b/src/hidapi.rs
@@ -19,7 +19,9 @@ const STRING_BUF_LEN: usize = 128;
 pub struct HidApiBackend;
 
 impl HidApiBackend {
-    pub fn populate_hid_device_info_vector(device_vector: &mut Vec<DeviceInfo>, vid: u16, pid: u16) -> HidResult<()> {
+    pub fn get_hid_device_info_vector(vid: u16, pid: u16) -> HidResult<Vec<DeviceInfo>> {
+        let mut device_vector = Vec::with_capacity(8);
+
         let enumeration = unsafe { ffi::hid_enumerate(vid, pid) };
         {
             let mut current_device = enumeration;
@@ -34,7 +36,7 @@ impl HidApiBackend {
             unsafe { ffi::hid_free_enumeration(enumeration) };
         }
 
-        Ok(())
+        Ok(device_vector)
     }
 
     pub fn open(vid: u16, pid: u16) -> HidResult<HidDevice> {

--- a/src/hidapi.rs
+++ b/src/hidapi.rs
@@ -19,10 +19,8 @@ const STRING_BUF_LEN: usize = 128;
 pub struct HidApiBackend;
 
 impl HidApiBackend {
-    pub fn get_hid_device_info_vector() -> HidResult<Vec<DeviceInfo>> {
-        let mut device_vector = Vec::with_capacity(8);
-
-        let enumeration = unsafe { ffi::hid_enumerate(0, 0) };
+    pub fn populate_hid_device_info_vector(device_vector: &mut Vec<DeviceInfo>, vid: u16, pid: u16) -> HidResult<()> {
+        let enumeration = unsafe { ffi::hid_enumerate(vid, pid) };
         {
             let mut current_device = enumeration;
 
@@ -36,7 +34,7 @@ impl HidApiBackend {
             unsafe { ffi::hid_free_enumeration(enumeration) };
         }
 
-        Ok(device_vector)
+        Ok(())
     }
 
     pub fn open(vid: u16, pid: u16) -> HidResult<HidDevice> {

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -214,7 +214,8 @@ impl HidApi {
     /// Indexes devices that match the given VID and PID filters.
     /// 0 indicates no filter.
     pub fn add_devices(&mut self, vid: u16, pid: u16) -> HidResult<()> {
-        HidApiBackend::populate_hid_device_info_vector(&mut self.device_list, vid, pid)
+        self.device_list.append(&mut HidApiBackend::get_hid_device_info_vector(vid, pid)?);
+        Ok(())
     }
 
     /// Returns iterator containing information about attached HID devices

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -173,9 +173,11 @@ impl HidApi {
     pub fn new() -> HidResult<Self> {
         lazy_init(true)?;
 
-        let device_list = HidApiBackend::get_hid_device_info_vector()?;
-
-        Ok(HidApi { device_list })
+        let mut api = HidApi {
+            device_list: Vec::with_capacity(8),
+        };
+        api.add_devices(0, 0)?;
+        Ok(api)
     }
 
     /// Create a new hidapi context, in "do not enumerate" mode.
@@ -196,13 +198,28 @@ impl HidApi {
 
     /// Refresh devices list and information about them (to access them use
     /// `device_list()` method)
+    /// Identical to `reset_devices()` followed by `add_devices(0, 0)`.
     pub fn refresh_devices(&mut self) -> HidResult<()> {
-        let device_list = HidApiBackend::get_hid_device_info_vector()?;
-        self.device_list = device_list;
+        self.reset_devices()?;
+        self.add_devices(0, 0)?;
         Ok(())
     }
 
-    /// Returns iterator containing information about attached HID devices.
+    /// Reset devices list. Intended to be used with the `add_devices` method.
+    pub fn reset_devices(&mut self) -> HidResult<()> {
+        self.device_list.clear();
+        Ok(())
+    }
+
+    /// Indexes devices that match the given VID and PID filters.
+    /// 0 indicates no filter.
+    pub fn add_devices(&mut self, vid: u16, pid: u16) -> HidResult<()> {
+        HidApiBackend::populate_hid_device_info_vector(&mut self.device_list, vid, pid)?;
+        Ok(())
+    }
+
+    /// Returns iterator containing information about attached HID devices
+    /// that have been indexed, either by `refresh_devices` or `add_devices`.
     pub fn device_list(&self) -> impl Iterator<Item = &DeviceInfo> {
         self.device_list.iter()
     }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -214,8 +214,7 @@ impl HidApi {
     /// Indexes devices that match the given VID and PID filters.
     /// 0 indicates no filter.
     pub fn add_devices(&mut self, vid: u16, pid: u16) -> HidResult<()> {
-        HidApiBackend::populate_hid_device_info_vector(&mut self.device_list, vid, pid)?;
-        Ok(())
+        HidApiBackend::populate_hid_device_info_vector(&mut self.device_list, vid, pid)
     }
 
     /// Returns iterator containing information about attached HID devices

--- a/src/linux_native.rs
+++ b/src/linux_native.rs
@@ -48,9 +48,9 @@ impl HidApiBackend {
 
         let devices = scan
             .filter_map(|device| device_to_hid_device_info(&device))
+            .flatten()
             .filter(|device| vid == 0 || device.vendor_id == vid)
             .filter(|device| pid == 0 || device.product_id == pid)
-            .flatten()
             .collect::<Vec<_>>();
 
         Ok(devices)

--- a/src/windows_native/mod.rs
+++ b/src/windows_native/mod.rs
@@ -47,8 +47,8 @@ macro_rules! ensure {
 
 pub struct HidApiBackend;
 impl HidApiBackend {
-    pub fn get_hid_device_info_vector() -> HidResult<Vec<DeviceInfo>> {
-        Ok(enumerate_devices(0, 0)?)
+    pub fn get_hid_device_info_vector(vid: u16, pid: u16) -> HidResult<Vec<DeviceInfo>> {
+        Ok(enumerate_devices(vid, pid)?)
     }
 
     pub fn open(vid: u16, pid: u16) -> HidResult<HidDevice> {


### PR DESCRIPTION
Enumerating all devices is rather undesirable, because it may require communicating with each device at each refresh, which is made even worse by the fact that some mice interupt their input for this communication. Combine that with an app that refreshes devices regularly and you've got very laggy mouse input.

These new APIs gives apps an alternative to:
```Rust
hid.refresh_devices()?;
```
With more narrow scoping:
```Rust
hid.reset_devices()?;
hid.add_devices(0x31E3, 0)?;
hid.add_devices(0x03EB, 0xFF01)?;
hid.add_devices(0x03EB, 0xFF02)?;
```