### PR TITLE
Reduce package size

### DIFF
--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -5,6 +5,7 @@ on:
     branches: [ master ]
   pull_request:
     branches: [ master ]
+  workflow_dispatch:
 
 env:
   CARGO_TERM_COLOR: always

--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -53,6 +53,10 @@ jobs:
       run: cargo build --no-default-features --features linux-${{ matrix.linkage }}-${{ matrix.library }} --verbose
     - name: Run tests
       run: cargo test --no-default-features --features linux-${{ matrix.linkage }}-${{ matrix.library }} --verbose
+    - name: Verify package
+      run: |
+        rm -f ./etc/libusb/README.md
+        cargo package --no-default-features --features linux-${{ matrix.linkage }}-${{ matrix.library }} --verbose
 
   build-linux-native:
     runs-on: ubuntu-latest
@@ -71,6 +75,8 @@ jobs:
       run: cargo build --no-default-features --features linux-native --verbose
     - name: Run tests
       run: cargo test --no-default-features --features linux-native --verbose
+    - name: Verify package
+      run: cargo package --no-default-features --features linux-native --verbose
 
   build-windows:
     runs-on: windows-latest
@@ -87,6 +93,8 @@ jobs:
       run: cargo build --no-default-features --verbose
     - name: Run tests
       run: cargo test --no-default-features --verbose
+    - name: Verify package
+      run: cargo package --no-default-features --verbose
 
   build-windows-native:
     runs-on: windows-latest
@@ -103,6 +111,8 @@ jobs:
         run: cargo build --no-default-features --features windows-native --verbose
       - name: Run tests
         run: cargo test --no-default-features --features windows-native --verbose
+      - name: Verify package
+        run: cargo package --no-default-features --features windows-native --verbose
 
   build-macos:
     runs-on: macos-latest
@@ -118,6 +128,8 @@ jobs:
       run: cargo build --no-default-features --verbose
     - name: Run tests
       run: cargo test --no-default-features --verbose
+    - name: Verify package
+      run: cargo package --no-default-features --verbose
 
   fmt-check:
     runs-on: ubuntu-latest

--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -55,6 +55,7 @@ jobs:
     - name: Run tests
       run: cargo test --no-default-features --features linux-${{ matrix.linkage }}-${{ matrix.library }} --verbose
     - name: Verify package
+      # TODO: Fix integration of libusb to avoid manual removal of README.md.
       run: |
         rm -f ./etc/libusb/README.md
         cargo package --no-default-features --features linux-${{ matrix.linkage }}-${{ matrix.library }} --verbose

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -17,6 +17,29 @@ build = "build.rs"
 links = "hidapi"
 documentation = "https://docs.rs/hidapi"
 edition = "2021"
+include = [
+    "README.md",
+    "LICENSE.txt",
+    "build.rs",
+    "/src",
+    "/etc/hidapi/CMakeLists.txt",
+    "/etc/hidapi/LICENSE*",
+    "/etc/hidapi/VERSION",
+    "/etc/hidapi/hidapi",
+    "/etc/hidapi/libusb",
+    "/etc/hidapi/src",
+    "/etc/hidapi/udev",
+    # Platform support files
+    "/etc/hidapi/linux/CMakeLists.txt",
+    "/etc/hidapi/linux/*.c",
+    "/etc/hidapi/linux/*.h",
+    "/etc/hidapi/mac/CMakeLists.txt",
+    "/etc/hidapi/mac/*.c",
+    "/etc/hidapi/mac/*.h",
+    "/etc/hidapi/windows/CMakeLists.txt",
+    "/etc/hidapi/windows/*.c",
+    "/etc/hidapi/windows/*.h",
+]
 
 [features]
 default = ["linux-static-hidraw", "illumos-static-libusb"]


### PR DESCRIPTION
The crate package does not need to include all files. Especially not everything in /etc/hidapi.

#### Before

Packaged 276 files, 2.2MiB (384.3KiB compressed)

#### After

Packaged 65 files, 472.4KiB (116.4KiB compressed)