### PR TITLE
hiddevice: add `AsFd` impl

### DIFF
--- a/src/linux_native.rs
+++ b/src/linux_native.rs
@@ -8,7 +8,7 @@ use std::{
     fs::{File, OpenOptions},
     io::{Cursor, Read, Seek, SeekFrom},
     os::{
-        fd::{AsRawFd, OwnedFd, AsFd, BorrowedFd},
+        fd::{AsFd, AsRawFd, BorrowedFd, OwnedFd},
         unix::{ffi::OsStringExt, fs::OpenOptionsExt},
     },
     path::{Path, PathBuf},

--- a/src/linux_native.rs
+++ b/src/linux_native.rs
@@ -8,7 +8,7 @@ use std::{
     fs::{File, OpenOptions},
     io::{Cursor, Read, Seek, SeekFrom},
     os::{
-        fd::{AsRawFd, OwnedFd},
+        fd::{AsRawFd, OwnedFd, AsFd, BorrowedFd},
         unix::{ffi::OsStringExt, fs::OpenOptionsExt},
     },
     path::{Path, PathBuf},
@@ -470,6 +470,12 @@ impl HidDevice {
 
         let info = self.info.borrow();
         Ok(Ref::map(info, |i: &Option<DeviceInfo>| i.as_ref().unwrap()))
+    }
+}
+
+impl AsFd for HidDevice {
+    fn as_fd(&self) -> BorrowedFd {
+        self.fd.as_fd()
     }
 }
 


### PR DESCRIPTION
This is useful to allow performing custom ioctls/operations on nonstandard HID devices.