### PR TITLE
Use CancelIoEx instead of CancelIo on windows_native

### DIFF
--- a/src/windows_native/mod.rs
+++ b/src/windows_native/mod.rs
@@ -46,7 +46,7 @@ use windows_sys::Win32::Storage::FileSystem::{
     OPEN_EXISTING,
 };
 use windows_sys::Win32::System::Threading::ResetEvent;
-use windows_sys::Win32::System::IO::{CancelIo, DeviceIoControl};
+use windows_sys::Win32::System::IO::{CancelIoEx, DeviceIoControl};
 
 const STRING_BUF_LEN: usize = 128;
 
@@ -179,7 +179,7 @@ impl HidDeviceBackendBase for HidDevice {
             if res != TRUE {
                 let err = Win32Error::last();
                 if err != Win32Error::IoPending {
-                    unsafe { CancelIo(self.device_handle.as_raw()) };
+                    unsafe { CancelIoEx(self.device_handle.as_raw(), state.overlapped.as_raw()) };
                     self.read_pending.set(false);
                     return Err(err.into());
                 }
@@ -335,7 +335,16 @@ impl HidDeviceBackendWindows for HidDevice {
 impl Drop for HidDevice {
     fn drop(&mut self) {
         unsafe {
-            CancelIo(self.device_handle.as_raw());
+            for state in [
+                &mut self.read_state,
+                &mut self.write_state,
+                &mut self.feature_state,
+            ] {
+                let mut state = state.borrow_mut();
+                if CancelIoEx(self.device_handle.as_raw(), state.overlapped.as_raw()) > 0 {
+                    _ = state.overlapped.get_result(&self.device_handle, None);
+                }
+            }
         }
     }
 }


### PR DESCRIPTION
Fixes a use-after-free bug when dropping the HidDevice from a thread other than the one that was last used to read it, because of a pending async operation that did not get canceled.

If the cancellation does not return an error, we get the overlapped result to block until it actually goes through. This is recommended by Microsoft in this example:
<https://learn.microsoft.com/en-us/windows/win32/fileio/canceling-pending-i-o-operations#canceling-asynchronous-io>.

Closes #151