### PR TITLE
Add `PartialEq`, `Eq` and `Hash` to `DeviceInfo`

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -303,7 +303,7 @@ impl HidApi {
 }
 
 #[allow(dead_code)]
-#[derive(Clone, PartialEq)]
+#[derive(Clone, PartialEq, Eq, Hash)]
 enum WcharString {
     String(String),
     #[cfg_attr(all(feature = "linux-native", target_os = "linux"), allow(dead_code))]
@@ -322,7 +322,7 @@ impl From<WcharString> for Option<String> {
 
 /// The underlying HID bus type.
 #[repr(C)]
-#[derive(Copy, Clone, Debug)]
+#[derive(Copy, Clone, Debug, PartialEq, Eq, Hash)]
 pub enum BusType {
     Unknown = 0x00,
     Usb = 0x01,
@@ -336,7 +336,7 @@ pub enum BusType {
 /// Note: Methods like `serial_number()` may return None, if the conversion to a
 /// String failed internally. You can however access the raw hid representation of the
 /// string by calling `serial_number_raw()`
-#[derive(Clone)]
+#[derive(Clone, PartialEq, Eq, Hash)]
 pub struct DeviceInfo {
     path: CString,
     vendor_id: u16,


### PR DESCRIPTION
Also added transitively to `BusType` and `WcharString`. As far as I can tell this is safe to do since their equality relation is total.

A simple change for consumer QoL. I am trying to poll the list of devices and need this to track changes on the list of devices (`libusb` hotplug is not yet available in Windows, so I have to resort to polling, and I have to use HID anyways).

I didn't particularly need hash (yet) but it felt right to add it semantically, and I can foresee me using the `DeviceInfo` in `HashSet` or `HashMap` at some point.