### PR TITLE
Add feature for doc_cfg, specify allowed cfgs in build.rs

### DIFF
--- a/build.rs
+++ b/build.rs
@@ -25,6 +25,9 @@ use std::env;
 fn main() {
     let target = env::var("TARGET").unwrap();
 
+    println!("cargo::rustc-check-cfg=cfg(hidapi)");
+    println!("cargo::rustc-check-cfg=cfg(libusb)");
+
     if target.contains("linux") {
         compile_linux();
     } else if target.contains("windows") {

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -59,6 +59,7 @@
 //! Since `hidapi` 0.12 it is possible to open MacOS devices with shared access, so that multiple
 //! [`HidDevice`] handles can access the same physical device. For backward compatibility this is
 //! an opt-in that can be enabled with the `macos-shared-device` feature flag.
+#![cfg_attr(docsrs, feature(doc_cfg))]
 
 mod error;
 mod ffi;


### PR DESCRIPTION
Specify possible configs as described in <https://doc.rust-lang.org/nightly/rustc/check-cfg.html>, and fix compilation with `--cfg docsrs`.