### PR TITLE
linux-native: provide better signatures for the ioctl wrappers

### DIFF
--- a/src/linux_native.rs
+++ b/src/linux_native.rs
@@ -524,14 +524,7 @@ impl HidDeviceBackendBase for HidDevice {
             return Err(HidError::InvalidZeroSizeData);
         }
 
-        // Have to crate owned buffer, because its not safe to cast shared
-        // reference to mutable reference, even if the underlying function never
-        // tries to mutate it.
-        let mut d = data.to_vec();
-
-        // The ioctl is marked as read-write so we need to mess with the
-        // mutability even though nothing should get written
-        let res = match unsafe { hidraw_ioc_set_feature(self.fd.as_raw_fd(), &mut d) } {
+        let res = match unsafe { hidraw_ioc_set_feature(self.fd.as_raw_fd(), data) } {
             Ok(n) => n as usize,
             Err(e) => {
                 return Err(HidError::HidApiError {

--- a/src/linux_native/ioctl.rs
+++ b/src/linux_native/ioctl.rs
@@ -1,6 +1,6 @@
 //! The IOCTL calls we need for the native linux backend
 
-use nix::{ioctl_read, ioctl_readwrite_buf};
+use nix::{ioctl_read, ioctl_read_buf, ioctl_write_buf};
 
 // From linux/hidraw.h
 const HIDRAW_IOC_MAGIC: u8 = b'H';
@@ -15,13 +15,13 @@ ioctl_read!(
     libc::c_int
 );
 
-ioctl_readwrite_buf!(
+ioctl_write_buf!(
     hidraw_ioc_set_feature,
     HIDRAW_IOC_MAGIC,
     HIDRAW_SET_FEATURE,
     u8
 );
-ioctl_readwrite_buf!(
+ioctl_read_buf!(
     hidraw_ioc_get_feature,
     HIDRAW_IOC_MAGIC,
     HIDRAW_GET_FEATURE,


### PR DESCRIPTION
It looks like I missed the write-only or read-only versions of these macros which let us specify that a ioctl is only writing or only reading.

Use them so we match the actual functionality. This also allows us to remove a copy when sending a feature report as we don't have to work around the misidentified mutability.