### PR TITLE
set_output_report (2nd version)

### DIFF
--- a/src/ffi.rs
+++ b/src/ffi.rs
@@ -63,6 +63,11 @@ extern "C" {
         data: *mut c_uchar,
         length: size_t,
     ) -> c_int;
+    pub fn hid_send_output_report(
+        device: *mut HidDevice,
+        data: *const c_uchar,
+        length: size_t,
+    ) -> c_int;
     pub fn hid_close(device: *mut HidDevice);
     pub fn hid_get_manufacturer_string(
         device: *mut HidDevice,

--- a/src/hidapi.rs
+++ b/src/hidapi.rs
@@ -251,6 +251,24 @@ impl HidDeviceBackendBase for HidDevice {
         self.check_size(res)
     }
 
+    fn send_output_report(&self, data: &[u8]) -> HidResult<()> {
+        if data.is_empty() {
+            return Err(HidError::InvalidZeroSizeData);
+        }
+        let res = unsafe {
+            ffi::hid_send_output_report(self._hid_device, data.as_ptr(), data.len() as size_t)
+        };
+        let res = self.check_size(res)?;
+        if res != data.len() {
+            Err(HidError::IncompleteSendError {
+                sent: res,
+                all: data.len(),
+            })
+        } else {
+            Ok(())
+        }
+    }
+
     fn set_blocking_mode(&self, blocking: bool) -> HidResult<()> {
         let res = unsafe {
             ffi::hid_set_nonblocking(self._hid_device, if blocking { 0i32 } else { 1i32 })

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -476,6 +476,7 @@ trait HidDeviceBackendBase {
     fn read_timeout(&self, buf: &mut [u8], timeout: i32) -> HidResult<usize>;
     fn send_feature_report(&self, data: &[u8]) -> HidResult<()>;
     fn get_feature_report(&self, buf: &mut [u8]) -> HidResult<usize>;
+    fn send_output_report(&self, data: &[u8]) -> HidResult<()>;
     fn set_blocking_mode(&self, blocking: bool) -> HidResult<()>;
     fn get_device_info(&self) -> HidResult<DeviceInfo>;
     fn get_manufacturer_string(&self) -> HidResult<Option<String>>;
@@ -592,6 +593,23 @@ impl HidDevice {
     /// in the first byte).
     pub fn get_feature_report(&self, buf: &mut [u8]) -> HidResult<usize> {
         self.inner.get_feature_report(buf)
+    }
+
+    // Send a Output report to the device.
+    //
+    // Output reports are sent over the Control endpoint as a Set_Report
+    // transfer. The first byte of data[] must contain the Report ID.
+    // For devices which only support a single report, this must be set
+    // to 0x0. The remaining bytes contain the report data. Since the
+    // Report ID is mandatory, calls to hid_send_output_report() will
+    // always contain one more byte than the report contains. For example,
+    //  if a hid report is 16 bytes long, 17 bytes must be passed to
+    //  hid_send_output_report(): the Report ID (or 0x0, for devices
+    // which do not use numbered reports), followed by the report
+    // data (16 bytes). In this example, the length passed in
+    // would be 17.
+    pub fn send_output_report(&self, data: &[u8]) -> HidResult<()> {
+        self.inner.send_output_report(data)
     }
 
     /// Set the device handle to be in blocking or in non-blocking mode. In

--- a/src/linux_native/ioctl.rs
+++ b/src/linux_native/ioctl.rs
@@ -7,6 +7,7 @@ const HIDRAW_IOC_MAGIC: u8 = b'H';
 const HIDRAW_IOC_GRDESCSIZE: u8 = 0x01;
 const HIDRAW_SET_FEATURE: u8 = 0x06;
 const HIDRAW_GET_FEATURE: u8 = 0x07;
+const HIDRAW_SET_OUTPUT: u8 = 0x0b;
 
 ioctl_read!(
     hidraw_ioc_grdescsize,
@@ -25,5 +26,11 @@ ioctl_read_buf!(
     hidraw_ioc_get_feature,
     HIDRAW_IOC_MAGIC,
     HIDRAW_GET_FEATURE,
+    u8
+);
+ioctl_write_buf!(
+    hidraw_ioc_set_output,
+    HIDRAW_IOC_MAGIC,
+    HIDRAW_SET_OUTPUT,
     u8
 );


### PR DESCRIPTION
Adds abstraction for `hid_send_output_report()`. As the function was added in `hidapi` v0.15 - the submodule had to be updated.

This PR replaces https://github.com/ruabmbua/hidapi-rs/pull/159 which doesn't compile.