### PR TITLE
Add async for linux-native

### DIFF
--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -74,11 +74,13 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        features:
+        backend:
           - linux-native
           - linux-native-basic-udev
-          - linux-native-async
-          - linux-native-tokio
+        async:
+          - ''
+          - async-io
+          - tokio
     steps:
       - name: Checkout repository and submodules
         uses: actions/checkout@v4
@@ -91,11 +93,11 @@ jobs:
       - name: Install Rust toolchain
         uses: dtolnay/rust-toolchain@stable
       - name: Build
-        run: cargo build --no-default-features --features ${{ matrix.features }} --verbose
+        run: cargo build --no-default-features --features ${{ matrix.backend }},${{ matrix.async }} --verbose
       - name: Run tests
-        run: cargo test --no-default-features --features ${{ matrix.features }} --verbose
+        run: cargo test --no-default-features --features ${{ matrix.backend }},${{ matrix.async }} --verbose
       - name: Verify package
-        run: cargo package --no-default-features --features ${{ matrix.features }} --verbose
+        run: cargo package --no-default-features --features ${{ matrix.backend }},${{ matrix.async }} --verbose
 
   build-windows:
     runs-on: windows-latest

--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -71,6 +71,14 @@ jobs:
     runs-on: ubuntu-latest
     env:
       DEBIAN_FRONTEND: noninteractive
+    strategy:
+      fail-fast: false
+      matrix:
+        features:
+          - linux-native
+          - linux-native-basic-udev
+          - linux-native-async
+          - linux-native-tokio
     steps:
       - name: Checkout repository and submodules
         uses: actions/checkout@v4
@@ -83,33 +91,11 @@ jobs:
       - name: Install Rust toolchain
         uses: dtolnay/rust-toolchain@stable
       - name: Build
-        run: cargo build --no-default-features --features linux-native --verbose
+        run: cargo build --no-default-features --features ${{ matrix.features }} --verbose
       - name: Run tests
-        run: cargo test --no-default-features --features linux-native --verbose
+        run: cargo test --no-default-features --features ${{ matrix.features }} --verbose
       - name: Verify package
-        run: cargo package --no-default-features --features linux-native --verbose
-
-  build-linux-native-basic-udev:
-    runs-on: ubuntu-latest
-    env:
-      DEBIAN_FRONTEND: noninteractive
-    steps:
-      - name: Checkout repository and submodules
-        uses: actions/checkout@v4
-        with:
-          submodules: recursive
-      - name: Install dependencies
-        run: |
-          sudo apt-get update -y
-          sudo apt-get install -y libudev-dev
-      - name: Install Rust toolchain
-        uses: dtolnay/rust-toolchain@stable
-      - name: Build
-        run: cargo build --no-default-features --features linux-native-basic-udev --verbose
-      - name: Run tests
-        run: cargo test --no-default-features --features linux-native-basic-udev --verbose
-      - name: Verify package
-        run: cargo package --no-default-features --features linux-native-basic-udev --verbose
+        run: cargo package --no-default-features --features ${{ matrix.features }} --verbose
 
   build-windows:
     runs-on: windows-latest

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -43,6 +43,7 @@ include = [
 
 [features]
 default = ["linux-static-hidraw", "illumos-static-libusb"]
+async = ["dep:futures"]
 linux-static-libusb = []
 linux-static-hidraw = []
 linux-shared-libusb = []
@@ -67,6 +68,7 @@ windows-native = [
 [dependencies]
 libc = "0.2"
 cfg-if = "1"
+futures = { version = "0.3", optional = true }
 
 [target.'cfg(target_os = "linux")'.dependencies]
 udev = { version = "0.8", optional = true }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -48,8 +48,6 @@ linux-static-hidraw = []
 linux-shared-libusb = []
 linux-shared-hidraw = []
 linux-native = ["dep:udev", "dep:nix"]
-linux-native-async = ["linux-native", "__async", "dep:async-io"]
-linux-native-tokio = ["linux-native", "__async", "dep:tokio"]
 linux-native-basic-udev = ["dep:basic-udev", "dep:nix"]
 illumos-static-libusb = []
 illumos-shared-libusb = []
@@ -65,6 +63,12 @@ windows-native = [
     "windows-sys/Win32_System_Threading",
     "windows-sys/Win32_UI_Shell_PropertiesSystem"
 ]
+
+# Enable async via the async-io crate
+async-io = ["__async", "dep:async-io"]
+
+#Enable async via the tokio crate
+tokio = ["__async", "dep:tokio"]
 
 # Enables some common code to do with async
 __async = ["dep:futures"]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -50,6 +50,7 @@ linux-shared-libusb = []
 linux-shared-hidraw = []
 linux-native = ["dep:udev", "dep:nix"]
 linux-native-async = ["linux-native", "async", "dep:async-io"]
+linux-native-tokio = ["linux-native", "async", "dep:tokio"]
 linux-native-basic-udev = ["dep:basic-udev", "dep:nix"]
 illumos-static-libusb = []
 illumos-shared-libusb = []
@@ -71,6 +72,7 @@ libc = "0.2"
 cfg-if = "1"
 futures = { version = "0.3", optional = true }
 async-io = { version = "2", optional = true }
+tokio = { version = "1", optional = true, features = ["net"] }
 
 [target.'cfg(target_os = "linux")'.dependencies]
 udev = { version = "0.8", optional = true }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -43,14 +43,13 @@ include = [
 
 [features]
 default = ["linux-static-hidraw", "illumos-static-libusb"]
-async = ["dep:futures"]
 linux-static-libusb = []
 linux-static-hidraw = []
 linux-shared-libusb = []
 linux-shared-hidraw = []
 linux-native = ["dep:udev", "dep:nix"]
-linux-native-async = ["linux-native", "async", "dep:async-io"]
-linux-native-tokio = ["linux-native", "async", "dep:tokio"]
+linux-native-async = ["linux-native", "__async", "dep:async-io"]
+linux-native-tokio = ["linux-native", "__async", "dep:tokio"]
 linux-native-basic-udev = ["dep:basic-udev", "dep:nix"]
 illumos-static-libusb = []
 illumos-shared-libusb = []
@@ -66,6 +65,9 @@ windows-native = [
     "windows-sys/Win32_System_Threading",
     "windows-sys/Win32_UI_Shell_PropertiesSystem"
 ]
+
+# Enables some common code to do with async
+__async = ["dep:futures"]
 
 [dependencies]
 libc = "0.2"
@@ -91,7 +93,7 @@ pkg-config = "0.3"
 
 [[example]]
 name = "co2mon-tokio"
-required-features = ["async"]
+required-features = ["__async"]
 
 [package.metadata.docs.rs]
 rustdoc-args = ["--cfg", "docsrs"]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -82,9 +82,16 @@ nix = { version = "0.27", optional = true, features = ["fs", "ioctl", "poll"] }
 [target.'cfg(windows)'.dependencies]
 windows-sys = { version = "0.48", features = ["Win32_Foundation"] }
 
+[target.'cfg(target_os = "linux")'.dev-dependencies]
+tokio = { version = "1", features = ["rt", "macros", "time"] }
+
 [build-dependencies]
 cc = "1.0"
 pkg-config = "0.3"
+
+[[example]]
+name = "co2mon-tokio"
+required-features = ["async"]
 
 [package.metadata.docs.rs]
 rustdoc-args = ["--cfg", "docsrs"]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -49,6 +49,7 @@ linux-static-hidraw = []
 linux-shared-libusb = []
 linux-shared-hidraw = []
 linux-native = ["dep:udev", "dep:nix"]
+linux-native-async = ["linux-native", "async", "dep:async-io"]
 linux-native-basic-udev = ["dep:basic-udev", "dep:nix"]
 illumos-static-libusb = []
 illumos-shared-libusb = []
@@ -69,6 +70,7 @@ windows-native = [
 libc = "0.2"
 cfg-if = "1"
 futures = { version = "0.3", optional = true }
+async-io = { version = "2", optional = true }
 
 [target.'cfg(target_os = "linux")'.dependencies]
 udev = { version = "0.8", optional = true }

--- a/examples/co2mon-tokio.rs
+++ b/examples/co2mon-tokio.rs
@@ -1,0 +1,63 @@
+/****************************************************************************
+    Copyright (c) 2015 Artyom Pavlov All Rights Reserved.
+
+    This file is part of hidapi-rs, based on hidapi_rust by Roland Ruckerbauer.
+    It's also based on the Oleg Bulatov's work (https://github.com/dmage/co2mon)
+****************************************************************************/
+
+//! Opens a KIT MT 8057 CO2 detector and reads data from it. This
+//! example will not work unless such an HID is plugged in to your system.
+
+extern crate hidapi;
+
+use hidapi::{HidApi, HidError};
+use std::time::Duration;
+
+use tokio::time::timeout;
+
+// Reuse the code from the co2mon example so we're not writing the decoding and
+// decrypting code multiple times.
+#[allow(dead_code)]
+#[path = "co2mon.rs"]
+mod co2mon;
+
+use co2mon::*;
+
+#[tokio::main(flavor = "current_thread")]
+async fn main() -> Result<(), HidError> {
+    let api = HidApi::new().expect("HID API object creation failed");
+    let dev = api.open(DEV_VID, DEV_PID)?;
+    dev.send_feature_report(&[0; PACKET_SIZE])?;
+
+    if let Some(manufacturer) = dev.get_manufacturer_string()? {
+        println!("Manufacurer:\t{manufacturer}");
+    }
+    if let Some(product) = dev.get_product_string()? {
+        println!("Product:\t{product}");
+    }
+    if let Some(serial_number) = dev.get_serial_number_string()? {
+        println!("Serial number:\t{serial_number}");
+    }
+
+    loop {
+        let mut buf = [0; PACKET_SIZE];
+        let n = timeout(
+            Duration::from_millis(HID_TIMEOUT as u64),
+            dev.async_read(&mut buf[..]),
+        )
+        .await
+        .map_err(|_| invalid_data_err("timeout"))??;
+        if n != PACKET_SIZE {
+            let msg = format!("unexpected packet length: {n}/{PACKET_SIZE}");
+            return Err(invalid_data_err(msg));
+        }
+        match decode_buf(buf) {
+            CO2Result::Temperature(val) => println!("Temp:\t{:?}", val),
+            CO2Result::Concentration(val) => println!("Conc:\t{:?}", val),
+            CO2Result::Unknown(kind, val) => eprintln!("Unknown({kind:x}):\t{val}"),
+            CO2Result::Error(msg) => {
+                return Err(invalid_data_err(msg));
+            }
+        }
+    }
+}

--- a/examples/co2mon.rs
+++ b/examples/co2mon.rs
@@ -11,27 +11,27 @@
 use hidapi::{HidApi, HidError};
 use std::io;
 
-const CODE_TEMPERATURE: u8 = 0x42;
-const CODE_CONCENTRATION: u8 = 0x50;
-const HID_TIMEOUT: i32 = 5000;
-const DEV_VID: u16 = 0x04d9;
-const DEV_PID: u16 = 0xa052;
-const PACKET_SIZE: usize = 8;
+pub const CODE_TEMPERATURE: u8 = 0x42;
+pub const CODE_CONCENTRATION: u8 = 0x50;
+pub const HID_TIMEOUT: i32 = 5000;
+pub const DEV_VID: u16 = 0x04d9;
+pub const DEV_PID: u16 = 0xa052;
+pub const PACKET_SIZE: usize = 8;
 
-type Packet = [u8; PACKET_SIZE];
+pub type Packet = [u8; PACKET_SIZE];
 
-enum CO2Result {
+pub enum CO2Result {
     Temperature(f32),
     Concentration(u16),
     Unknown(u8, u16),
     Error(&'static str),
 }
 
-fn decode_temperature(value: u16) -> f32 {
+pub fn decode_temperature(value: u16) -> f32 {
     (value as f32) * 0.0625 - 273.15
 }
 
-fn decrypt(buf: Packet) -> Packet {
+pub fn decrypt(buf: Packet) -> Packet {
     let mut res: [u8; PACKET_SIZE] = [
         (buf[3] << 5) | (buf[2] >> 3),
         (buf[2] << 5) | (buf[4] >> 3),
@@ -52,7 +52,7 @@ fn decrypt(buf: Packet) -> Packet {
     res
 }
 
-fn decode_buf(buf: Packet) -> CO2Result {
+pub fn decode_buf(buf: Packet) -> CO2Result {
     // Do we need to decrypt the data?
     let res = if buf[4] == 0x0d { buf } else { decrypt(buf) };
 
@@ -82,7 +82,7 @@ fn decode_buf(buf: Packet) -> CO2Result {
     }
 }
 
-fn invalid_data_err(msg: impl Into<String>) -> HidError {
+pub fn invalid_data_err(msg: impl Into<String>) -> HidError {
     HidError::IoError {
         error: io::Error::new(io::ErrorKind::InvalidData, msg.into()),
     }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -39,6 +39,7 @@
 //!
 //! # Feature flags
 //!
+//! - `async`: enable the async functions (must be paired with a supported backend)
 //! - `linux-static-libusb`: uses statically linked `libusb` backend on Linux
 //! - `linux-static-hidraw`: uses statically linked `hidraw` backend on Linux (default)
 //! - `linux-shared-libusb`: uses dynamically linked `libusb` backend on Linux
@@ -65,12 +66,20 @@ mod error;
 mod ffi;
 
 use cfg_if::cfg_if;
+
+// Catch async being enabled with an unsupported backend
+#[cfg(all(feature = "async", not(feature = "linux-native")))]
+compile_error!("async is only supported for some backends");
+
 use libc::wchar_t;
 use std::ffi::CStr;
 use std::ffi::CString;
 use std::fmt;
 use std::fmt::Debug;
 use std::sync::Mutex;
+
+#[cfg(feature = "async")]
+use futures::task::{Context, Poll};
 
 pub use error::HidError;
 
@@ -490,6 +499,10 @@ trait HidDeviceBackendBase {
     fn write(&self, data: &[u8]) -> HidResult<usize>;
     fn read(&self, buf: &mut [u8]) -> HidResult<usize>;
     fn read_timeout(&self, buf: &mut [u8], timeout: i32) -> HidResult<usize>;
+    #[cfg(feature = "async")]
+    fn poll_write(&mut self, cx: &mut Context<'_>, buf: &[u8]) -> Poll<HidResult<usize>>;
+    #[cfg(feature = "async")]
+    fn poll_read(&self, cx: &mut Context<'_>, buf: &mut [u8]) -> Poll<HidResult<usize>>;
     fn send_feature_report(&self, data: &[u8]) -> HidResult<()>;
     fn get_feature_report(&self, buf: &mut [u8]) -> HidResult<usize>;
     fn send_output_report(&self, data: &[u8]) -> HidResult<()>;
@@ -683,5 +696,24 @@ impl HidDevice {
     /// Get [`DeviceInfo`] from a HID device.
     pub fn get_device_info(&self) -> HidResult<DeviceInfo> {
         self.inner.get_device_info()
+    }
+}
+
+#[cfg(feature = "async")]
+impl HidDevice {
+    /// Write asynchronously to the device.
+    ///
+    /// See [`write`][`Self::write`] for more information.
+    #[cfg_attr(docsrs, doc(cfg(feature = "async")))]
+    pub async fn async_write(&mut self, buf: &[u8]) -> HidResult<usize> {
+        futures::future::poll_fn(|cx| self.inner.poll_write(cx, buf)).await
+    }
+
+    /// Read asynchronously from the device
+    ///
+    /// See [`read`][`Self::read`] for more information.
+    #[cfg_attr(docsrs, doc(cfg(feature = "async")))]
+    pub async fn async_read(&self, buf: &mut [u8]) -> HidResult<usize> {
+        futures::future::poll_fn(|cx| self.inner.poll_read(cx, buf)).await
     }
 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -39,17 +39,26 @@
 //!
 //! # Feature flags
 //!
+//! ## Backends
+//!
 //! - `linux-static-libusb`: uses statically linked `libusb` backend on Linux
 //! - `linux-static-hidraw`: uses statically linked `hidraw` backend on Linux (default)
 //! - `linux-shared-libusb`: uses dynamically linked `libusb` backend on Linux
 //! - `linux-shared-hidraw`: uses dynamically linked `hidraw` backend on Linux
 //! - `linux-native`: talks to hidraw directly without using the `hidapi` C library
-//! - `linux-native-async`: like `linux-native` but additionally enables `async-io`-backed async
-//! - `linux-native-tokio`: like `linux-native` but additionally enables `tokio`-backed async
 //! - `illumos-static-libusb`: uses statically linked `libusb` backend on Illumos (default)
 //! - `illumos-shared-libusb`: uses statically linked `hidraw` backend on Illumos
 //! - `macos-shared-device`: enables shared access to HID devices on MacOS
 //! - `windows-native`: talks to hid.dll directly without using the `hidapi` C library
+//!
+//! ## Async backends
+//!
+//! For some backends (`linux-native` for now) we support some operations
+//! running async. You can choose what to use. If you are not using tokio
+//! yourself, select `async-io`
+//!
+//! - `async-io`: use smol-rs's [async-io](https://crates.io/crates/async-io) to enable async support
+//! - `tokio`: use [tokio](https://crates.io/crates/tokio) to enable async support
 //!
 //! ## Linux backends
 //!
@@ -67,6 +76,10 @@ mod error;
 mod ffi;
 
 use cfg_if::cfg_if;
+
+// You can only select a single async backend for us
+#[cfg(all(feature = "async-io", feature = "tokio"))]
+compile_error!("A maximum of one async backend can be selected");
 
 // Catch async being enabled with an unsupported backend
 #[cfg(all(feature = "__async", not(feature = "linux-native")))]

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -69,7 +69,7 @@ mod ffi;
 use cfg_if::cfg_if;
 
 // Catch async being enabled with an unsupported backend
-#[cfg(all(feature = "async", not(feature = "linux-native")))]
+#[cfg(all(feature = "__async", not(feature = "linux-native")))]
 compile_error!("async is only supported for some backends");
 
 use libc::wchar_t;
@@ -79,7 +79,7 @@ use std::fmt;
 use std::fmt::Debug;
 use std::sync::Mutex;
 
-#[cfg(feature = "async")]
+#[cfg(feature = "__async")]
 use futures::task::{Context, Poll};
 
 pub use error::HidError;
@@ -139,7 +139,7 @@ cfg_if! {
 //
 // In this block we set up whether the top-level trait should include the async trait
 cfg_if! {
-    if #[cfg(feature = "async")] {
+    if #[cfg(feature = "__async")] {
         trait HidDeviceBackend: HidDeviceBackendSync + HidDeviceBackendBaseAsync {}
         impl<T> HidDeviceBackend for T where T: HidDeviceBackendSync + HidDeviceBackendBaseAsync {}
     } else {
@@ -535,7 +535,7 @@ trait HidDeviceBackendBase {
 }
 
 /// Trait which the different backends must implement if they support async code
-#[cfg(feature = "async")]
+#[cfg(feature = "__async")]
 trait HidDeviceBackendBaseAsync {
     fn poll_write(&mut self, cx: &mut Context<'_>, buf: &[u8]) -> Poll<HidResult<usize>>;
     fn poll_read(&self, cx: &mut Context<'_>, buf: &mut [u8]) -> Poll<HidResult<usize>>;
@@ -718,12 +718,12 @@ impl HidDevice {
     }
 }
 
-#[cfg(feature = "async")]
+#[cfg(feature = "__async")]
 impl HidDevice {
     /// Write asynchronously to the device.
     ///
     /// See [`write`][`Self::write`] for more information.
-    #[cfg_attr(docsrs, doc(cfg(feature = "async")))]
+    #[cfg_attr(docsrs, doc(cfg(feature = "__async")))]
     pub async fn async_write(&mut self, buf: &[u8]) -> HidResult<usize> {
         futures::future::poll_fn(|cx| self.inner.poll_write(cx, buf)).await
     }
@@ -731,7 +731,7 @@ impl HidDevice {
     /// Read asynchronously from the device
     ///
     /// See [`read`][`Self::read`] for more information.
-    #[cfg_attr(docsrs, doc(cfg(feature = "async")))]
+    #[cfg_attr(docsrs, doc(cfg(feature = "__async")))]
     pub async fn async_read(&self, buf: &mut [u8]) -> HidResult<usize> {
         futures::future::poll_fn(|cx| self.inner.poll_read(cx, buf)).await
     }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -101,6 +101,8 @@ cfg_if! {
 }
 
 // Automatically implement the top trait
+//
+// In this block we set up what the trait should be for the sync version
 cfg_if! {
     if #[cfg(target_os = "windows")] {
         #[cfg_attr(docsrs, doc(cfg(target_os = "windows")))]
@@ -111,8 +113,8 @@ cfg_if! {
             /// Get the container ID for a HID device
             fn get_container_id(&self) -> HidResult<GUID>;
         }
-        trait HidDeviceBackend: HidDeviceBackendBase + HidDeviceBackendWindows + Send {}
-        impl<T> HidDeviceBackend for T where T: HidDeviceBackendBase + HidDeviceBackendWindows + Send {}
+        trait HidDeviceBackendSync: HidDeviceBackendBase + HidDeviceBackendWindows + Send {}
+        impl<T> HidDeviceBackendSync for T where T: HidDeviceBackendBase + HidDeviceBackendWindows + Send {}
     } else if #[cfg(target_os = "macos")] {
         #[cfg_attr(docsrs, doc(cfg(target_os = "macos")))]
         mod macos;
@@ -124,11 +126,24 @@ cfg_if! {
             /// Check if the device was opened in exclusive mode.
             fn is_open_exclusive(&self) -> HidResult<bool>;
         }
-        trait HidDeviceBackend: HidDeviceBackendBase + HidDeviceBackendMacos + Send {}
-        impl<T> HidDeviceBackend for T where T: HidDeviceBackendBase + HidDeviceBackendMacos + Send {}
+        trait HidDeviceBackendSync: HidDeviceBackendBase + HidDeviceBackendMacos + Send {}
+        impl<T> HidDeviceBackendSync for T where T: HidDeviceBackendBase + HidDeviceBackendMacos + Send {}
     } else {
-        trait HidDeviceBackend: HidDeviceBackendBase + Send {}
-        impl<T> HidDeviceBackend for T where T: HidDeviceBackendBase + Send {}
+            trait HidDeviceBackendSync: HidDeviceBackendBase + Send {}
+            impl<T> HidDeviceBackendSync for T where T: HidDeviceBackendBase + Send {}
+    }
+}
+
+// Automatically implement the top trait
+//
+// In this block we set up whether the top-level trait should include the async trait
+cfg_if! {
+    if #[cfg(feature = "async")] {
+        trait HidDeviceBackend: HidDeviceBackendSync + HidDeviceBackendBaseAsync {}
+        impl<T> HidDeviceBackend for T where T: HidDeviceBackendSync + HidDeviceBackendBaseAsync {}
+    } else {
+        trait HidDeviceBackend: HidDeviceBackendSync {}
+        impl<T> HidDeviceBackend for T where T: HidDeviceBackendSync {}
     }
 }
 
@@ -499,10 +514,6 @@ trait HidDeviceBackendBase {
     fn write(&self, data: &[u8]) -> HidResult<usize>;
     fn read(&self, buf: &mut [u8]) -> HidResult<usize>;
     fn read_timeout(&self, buf: &mut [u8], timeout: i32) -> HidResult<usize>;
-    #[cfg(feature = "async")]
-    fn poll_write(&mut self, cx: &mut Context<'_>, buf: &[u8]) -> Poll<HidResult<usize>>;
-    #[cfg(feature = "async")]
-    fn poll_read(&self, cx: &mut Context<'_>, buf: &mut [u8]) -> Poll<HidResult<usize>>;
     fn send_feature_report(&self, data: &[u8]) -> HidResult<()>;
     fn get_feature_report(&self, buf: &mut [u8]) -> HidResult<usize>;
     fn send_output_report(&self, data: &[u8]) -> HidResult<()>;
@@ -520,6 +531,13 @@ trait HidDeviceBackendBase {
             message: "get_indexed_string: not supported".to_string(),
         })
     }
+}
+
+/// Trait which the different backends must implement if they support async code
+#[cfg(feature = "async")]
+trait HidDeviceBackendBaseAsync {
+    fn poll_write(&mut self, cx: &mut Context<'_>, buf: &[u8]) -> Poll<HidResult<usize>>;
+    fn poll_read(&self, cx: &mut Context<'_>, buf: &mut [u8]) -> Poll<HidResult<usize>>;
 }
 
 pub struct HidDevice {

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -45,6 +45,7 @@
 //! - `linux-shared-hidraw`: uses dynamically linked `hidraw` backend on Linux
 //! - `linux-native`: talks to hidraw directly without using the `hidapi` C library
 //! - `linux-native-async`: like `linux-native` but additionally enables `async-io`-backed async
+//! - `linux-native-tokio`: like `linux-native` but additionally enables `tokio`-backed async
 //! - `illumos-static-libusb`: uses statically linked `libusb` backend on Illumos (default)
 //! - `illumos-shared-libusb`: uses statically linked `hidraw` backend on Illumos
 //! - `macos-shared-device`: enables shared access to HID devices on MacOS

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -39,12 +39,12 @@
 //!
 //! # Feature flags
 //!
-//! - `async`: enable the async functions (must be paired with a supported backend)
 //! - `linux-static-libusb`: uses statically linked `libusb` backend on Linux
 //! - `linux-static-hidraw`: uses statically linked `hidraw` backend on Linux (default)
 //! - `linux-shared-libusb`: uses dynamically linked `libusb` backend on Linux
 //! - `linux-shared-hidraw`: uses dynamically linked `hidraw` backend on Linux
 //! - `linux-native`: talks to hidraw directly without using the `hidapi` C library
+//! - `linux-native-async`: like `linux-native` but additionally enables `async-io`-backed async
 //! - `illumos-static-libusb`: uses statically linked `libusb` backend on Illumos (default)
 //! - `illumos-shared-libusb`: uses statically linked `hidraw` backend on Illumos
 //! - `macos-shared-device`: enables shared access to HID devices on MacOS

--- a/src/linux_native.rs
+++ b/src/linux_native.rs
@@ -21,9 +21,9 @@ use libc::wchar_t;
 
 #[cfg(feature = "linux-native-async")]
 use async_io::Async;
-#[cfg(feature = "async")]
+#[cfg(feature = "__async")]
 use futures::task::{Context, Poll};
-#[cfg(feature = "async")]
+#[cfg(feature = "__async")]
 use std::task::ready;
 #[cfg(feature = "linux-native-tokio")]
 use tokio::io::unix::AsyncFd;
@@ -424,7 +424,7 @@ fn parse_hid_vid_pid(s: &str) -> Option<(u16, u16, u16)> {
 /// Object for accessing the HID device
 pub struct HidDevice {
     blocking: Cell<bool>,
-    #[cfg(not(feature = "async"))]
+    #[cfg(not(feature = "__async"))]
     fd: OwnedFd,
     #[cfg(feature = "linux-native-async")]
     fd: Async<OwnedFd>,

--- a/src/linux_native.rs
+++ b/src/linux_native.rs
@@ -18,6 +18,10 @@ use std::{
 };
 
 use libc::wchar_t;
+
+#[cfg(feature = "async")]
+use futures::task::{Context, Poll};
+
 use nix::{
     errno::Errno,
     poll::{poll, PollFd, PollFlags},
@@ -525,6 +529,16 @@ impl HidDeviceBackendBase for HidDevice {
             Err(Errno::EAGAIN) | Err(Errno::EINPROGRESS) => Ok(0),
             Err(e) => Err(e.into()),
         }
+    }
+
+    #[cfg(feature = "async")]
+    fn poll_write(&mut self, cx: &mut Context<'_>, buf: &[u8]) -> Poll<HidResult<usize>> {
+        todo!();
+    }
+
+    #[cfg(feature = "async")]
+    fn poll_read(&self, cx: &mut Context<'_>, buf: &mut [u8]) -> Poll<HidResult<usize>> {
+        todo!();
     }
 
     fn send_feature_report(&self, data: &[u8]) -> HidResult<()> {

--- a/src/linux_native.rs
+++ b/src/linux_native.rs
@@ -25,6 +25,8 @@ use async_io::Async;
 use futures::task::{Context, Poll};
 #[cfg(feature = "async")]
 use std::task::ready;
+#[cfg(feature = "linux-native-tokio")]
+use tokio::io::unix::AsyncFd;
 
 use cfg_if::cfg_if;
 
@@ -426,6 +428,8 @@ pub struct HidDevice {
     fd: OwnedFd,
     #[cfg(feature = "linux-native-async")]
     fd: Async<OwnedFd>,
+    #[cfg(feature = "linux-native-tokio")]
+    fd: AsyncFd<OwnedFd>,
     info: RefCell<Option<DeviceInfo>>,
 }
 
@@ -479,6 +483,13 @@ impl HidDevice {
         cfg_if! {
             if #[cfg(feature = "linux-native-async")] {
                 let fd = Async::new_nonblocking(fd)?;
+                Ok(Self {
+                    blocking: Cell::new(true),
+                    fd,
+                    info: RefCell::new(None),
+                })
+            } else if #[cfg(feature = "linux-native-tokio")] {
+                let fd = AsyncFd::new(fd)?;
                 Ok(Self {
                     blocking: Cell::new(true),
                     fd,
@@ -688,6 +699,33 @@ impl super::HidDeviceBackendBaseAsync for HidDevice {
                 res => return Poll::Ready(res).map_err(|e| e.into()),
             }
             let _ = ready!(self.fd.poll_readable(cx));
+        }
+    }
+}
+
+#[cfg(feature = "linux-native-tokio")]
+impl super::HidDeviceBackendBaseAsync for HidDevice {
+    fn poll_write(&mut self, cx: &mut Context<'_>, buf: &[u8]) -> Poll<HidResult<usize>> {
+        if buf.is_empty() {
+            return Poll::Ready(Err(HidError::InvalidZeroSizeData));
+        }
+
+        loop {
+            let mut guard = ready!(self.fd.poll_write_ready(cx))?;
+            match write(self.fd.as_raw_fd(), buf) {
+                Err(Errno::EWOULDBLOCK) => guard.clear_ready(),
+                res => return Poll::Ready(res).map_err(|e| e.into()),
+            }
+        }
+    }
+
+    fn poll_read(&self, cx: &mut Context<'_>, buf: &mut [u8]) -> Poll<HidResult<usize>> {
+        loop {
+            let mut guard = ready!(self.fd.poll_read_ready(cx))?;
+            match read(self.fd.as_raw_fd(), buf) {
+                Err(Errno::EWOULDBLOCK) => guard.clear_ready(),
+                res => return Poll::Ready(res).map_err(|e| e.into()),
+            }
         }
     }
 }

--- a/src/linux_native.rs
+++ b/src/linux_native.rs
@@ -19,8 +19,14 @@ use std::{
 
 use libc::wchar_t;
 
+#[cfg(feature = "linux-native-async")]
+use async_io::Async;
 #[cfg(feature = "async")]
 use futures::task::{Context, Poll};
+#[cfg(feature = "async")]
+use std::task::ready;
+
+use cfg_if::cfg_if;
 
 use nix::{
     errno::Errno,
@@ -416,7 +422,10 @@ fn parse_hid_vid_pid(s: &str) -> Option<(u16, u16, u16)> {
 /// Object for accessing the HID device
 pub struct HidDevice {
     blocking: Cell<bool>,
+    #[cfg(not(feature = "async"))]
     fd: OwnedFd,
+    #[cfg(feature = "linux-native-async")]
+    fd: Async<OwnedFd>,
     info: RefCell<Option<DeviceInfo>>,
 }
 
@@ -467,11 +476,22 @@ impl HidDevice {
             });
         }
 
-        Ok(Self {
-            blocking: Cell::new(true),
-            fd,
-            info: RefCell::new(None),
-        })
+        cfg_if! {
+            if #[cfg(feature = "linux-native-async")] {
+                let fd = Async::new_nonblocking(fd)?;
+                Ok(Self {
+                    blocking: Cell::new(true),
+                    fd,
+                    info: RefCell::new(None),
+                })
+            } else {
+                Ok(Self {
+                    blocking: Cell::new(true),
+                    fd,
+                    info: RefCell::new(None),
+                })
+            }
+        }
     }
 
     fn info(&self) -> HidResult<Ref<'_, DeviceInfo>> {
@@ -533,12 +553,28 @@ impl HidDeviceBackendBase for HidDevice {
 
     #[cfg(feature = "async")]
     fn poll_write(&mut self, cx: &mut Context<'_>, buf: &[u8]) -> Poll<HidResult<usize>> {
-        todo!();
+        if buf.is_empty() {
+            return Poll::Ready(Err(HidError::InvalidZeroSizeData));
+        }
+
+        loop {
+            match write(self.fd.as_raw_fd(), buf) {
+                Err(Errno::EWOULDBLOCK) => {}
+                res => return Poll::Ready(res).map_err(|e| e.into()),
+            }
+            let _ = ready!(self.fd.poll_writable(cx));
+        }
     }
 
     #[cfg(feature = "async")]
     fn poll_read(&self, cx: &mut Context<'_>, buf: &mut [u8]) -> Poll<HidResult<usize>> {
-        todo!();
+        loop {
+            match read(self.fd.as_raw_fd(), buf) {
+                Err(Errno::EWOULDBLOCK) => {}
+                res => return Poll::Ready(res).map_err(|e| e.into()),
+            }
+            let _ = ready!(self.fd.poll_readable(cx));
+        }
     }
 
     fn send_feature_report(&self, data: &[u8]) -> HidResult<()> {

--- a/src/linux_native.rs
+++ b/src/linux_native.rs
@@ -19,13 +19,13 @@ use std::{
 
 use libc::wchar_t;
 
-#[cfg(feature = "linux-native-async")]
+#[cfg(feature = "async-io")]
 use async_io::Async;
 #[cfg(feature = "__async")]
 use futures::task::{Context, Poll};
 #[cfg(feature = "__async")]
 use std::task::ready;
-#[cfg(feature = "linux-native-tokio")]
+#[cfg(feature = "tokio")]
 use tokio::io::unix::AsyncFd;
 
 use cfg_if::cfg_if;
@@ -426,9 +426,9 @@ pub struct HidDevice {
     blocking: Cell<bool>,
     #[cfg(not(feature = "__async"))]
     fd: OwnedFd,
-    #[cfg(feature = "linux-native-async")]
+    #[cfg(feature = "async-io")]
     fd: Async<OwnedFd>,
-    #[cfg(feature = "linux-native-tokio")]
+    #[cfg(feature = "tokio")]
     fd: AsyncFd<OwnedFd>,
     info: RefCell<Option<DeviceInfo>>,
 }
@@ -481,14 +481,14 @@ impl HidDevice {
         }
 
         cfg_if! {
-            if #[cfg(feature = "linux-native-async")] {
+            if #[cfg(feature = "async-io")] {
                 let fd = Async::new_nonblocking(fd)?;
                 Ok(Self {
                     blocking: Cell::new(true),
                     fd,
                     info: RefCell::new(None),
                 })
-            } else if #[cfg(feature = "linux-native-tokio")] {
+            } else if #[cfg(feature = "tokio")] {
                 let fd = AsyncFd::new(fd)?;
                 Ok(Self {
                     blocking: Cell::new(true),
@@ -676,7 +676,7 @@ impl HidDeviceBackendBase for HidDevice {
     }
 }
 
-#[cfg(feature = "linux-native-async")]
+#[cfg(feature = "async-io")]
 impl super::HidDeviceBackendBaseAsync for HidDevice {
     fn poll_write(&mut self, cx: &mut Context<'_>, buf: &[u8]) -> Poll<HidResult<usize>> {
         if buf.is_empty() {
@@ -703,7 +703,7 @@ impl super::HidDeviceBackendBaseAsync for HidDevice {
     }
 }
 
-#[cfg(feature = "linux-native-tokio")]
+#[cfg(feature = "tokio")]
 impl super::HidDeviceBackendBaseAsync for HidDevice {
     fn poll_write(&mut self, cx: &mut Context<'_>, buf: &[u8]) -> Poll<HidResult<usize>> {
         if buf.is_empty() {

--- a/src/linux_native.rs
+++ b/src/linux_native.rs
@@ -551,32 +551,6 @@ impl HidDeviceBackendBase for HidDevice {
         }
     }
 
-    #[cfg(feature = "async")]
-    fn poll_write(&mut self, cx: &mut Context<'_>, buf: &[u8]) -> Poll<HidResult<usize>> {
-        if buf.is_empty() {
-            return Poll::Ready(Err(HidError::InvalidZeroSizeData));
-        }
-
-        loop {
-            match write(self.fd.as_raw_fd(), buf) {
-                Err(Errno::EWOULDBLOCK) => {}
-                res => return Poll::Ready(res).map_err(|e| e.into()),
-            }
-            let _ = ready!(self.fd.poll_writable(cx));
-        }
-    }
-
-    #[cfg(feature = "async")]
-    fn poll_read(&self, cx: &mut Context<'_>, buf: &mut [u8]) -> Poll<HidResult<usize>> {
-        loop {
-            match read(self.fd.as_raw_fd(), buf) {
-                Err(Errno::EWOULDBLOCK) => {}
-                res => return Poll::Ready(res).map_err(|e| e.into()),
-            }
-            let _ = ready!(self.fd.poll_readable(cx));
-        }
-    }
-
     fn send_feature_report(&self, data: &[u8]) -> HidResult<()> {
         if data.is_empty() {
             return Err(HidError::InvalidZeroSizeData);
@@ -688,6 +662,33 @@ impl HidDeviceBackendBase for HidDevice {
         let min_size = buf.len().min(descriptor.0.len());
         buf[..min_size].copy_from_slice(&descriptor.0[..min_size]);
         Ok(min_size)
+    }
+}
+
+#[cfg(feature = "linux-native-async")]
+impl super::HidDeviceBackendBaseAsync for HidDevice {
+    fn poll_write(&mut self, cx: &mut Context<'_>, buf: &[u8]) -> Poll<HidResult<usize>> {
+        if buf.is_empty() {
+            return Poll::Ready(Err(HidError::InvalidZeroSizeData));
+        }
+
+        loop {
+            match write(self.fd.as_raw_fd(), buf) {
+                Err(Errno::EWOULDBLOCK) => {}
+                res => return Poll::Ready(res).map_err(|e| e.into()),
+            }
+            let _ = ready!(self.fd.poll_writable(cx));
+        }
+    }
+
+    fn poll_read(&self, cx: &mut Context<'_>, buf: &mut [u8]) -> Poll<HidResult<usize>> {
+        loop {
+            match read(self.fd.as_raw_fd(), buf) {
+                Err(Errno::EWOULDBLOCK) => {}
+                res => return Poll::Ready(res).map_err(|e| e.into()),
+            }
+            let _ = ready!(self.fd.poll_readable(cx));
+        }
     }
 }
 


### PR DESCRIPTION
This goes some of the way towards taking care of #51 though right now just for linux-native as it's the easiest to do (at least for me).

Doing async through traits can be a bit challenging. I played around with methods returning boxed futures but then you start having to care about the lifetimes of the buffers and those go into the signatures and it gets ugly.

Which is why I went with how everyone else does it, which is to have a `poll_{read,write}` method. We then use `futures::poll_fn` to make a future out of that.

As far as choosing which runtime flavour to use (given you can't go fully generic without implementing a bunch more things that the runtimes give you), I ended up going for both major ones as it was pretty easy to implement them both. The tokio variant works if you're using tokio without extra dependencies, and the smol/async-io version works wherever.

Unfortunately this is quite an explosion of feature flags to enable the user of the library to say what stack they're working on, but I don't know of a way to auto-select depending on what else is selected in a dependent project. And I haven't even tackled what happens if you want async but also basic-udev.

One thing I'm not sure here is the naming of the generic `async` feature as you're not meant to enable it yourself, but rather choose a backend. Maybe it should be `__async` to indicate it's internal. This is e.g. what I've seen `reqwest` does.