### PR TITLE
Upgrade dependencies, in particular `windows-sys` to 0.61 and `nix` to 0.30

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -53,11 +53,11 @@ illumos-static-libusb = []
 illumos-shared-libusb = []
 macos-shared-device = []
 windows-native = [
+    "windows/Win32_Storage_EnhancedStorage",
     "windows-sys/Win32_Devices_DeviceAndDriverInstallation",
     "windows-sys/Win32_Devices_HumanInterfaceDevice",
     "windows-sys/Win32_Devices_Properties",
     "windows-sys/Win32_Security",
-    "windows-sys/Win32_Storage_EnhancedStorage",
     "windows-sys/Win32_Storage_FileSystem",
     "windows-sys/Win32_System_IO",
     "windows-sys/Win32_System_Threading",
@@ -69,15 +69,16 @@ libc = "0.2"
 cfg-if = "1"
 
 [target.'cfg(target_os = "linux")'.dependencies]
-udev = { version = "0.8", optional = true }
+udev = { version = "0.9", optional = true }
 basic-udev = { version = "0.1", optional = true }
-nix = { version = "0.27", optional = true, features = ["fs", "ioctl", "poll"] }
+nix = { version = "0.30", optional = true, features = ["fs", "ioctl", "poll"] }
 
 [target.'cfg(windows)'.dependencies]
-windows-sys = { version = "0.48", features = ["Win32_Foundation"] }
+windows = { version = "0.62" }
+windows-sys = { version = "0.61", features = ["Win32_Foundation"] }
 
 [build-dependencies]
-cc = "1.0"
+cc = "1.2"
 pkg-config = "0.3"
 
 [package.metadata.docs.rs]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -53,7 +53,6 @@ illumos-static-libusb = []
 illumos-shared-libusb = []
 macos-shared-device = []
 windows-native = [
-    "windows/Win32_Storage_EnhancedStorage",
     "windows-sys/Win32_Devices_DeviceAndDriverInstallation",
     "windows-sys/Win32_Devices_HumanInterfaceDevice",
     "windows-sys/Win32_Devices_Properties",
@@ -74,7 +73,6 @@ basic-udev = { version = "0.1", optional = true }
 nix = { version = "0.30", optional = true, features = ["fs", "ioctl", "poll"] }
 
 [target.'cfg(windows)'.dependencies]
-windows = { version = "0.62" }
 windows-sys = { version = "0.61", features = ["Win32_Foundation"] }
 
 [build-dependencies]

--- a/src/linux_native.rs
+++ b/src/linux_native.rs
@@ -20,7 +20,7 @@ use std::{
 use libc::wchar_t;
 use nix::{
     errno::Errno,
-    poll::{poll, PollFd, PollFlags},
+    poll::{poll, PollFd, PollFlags, PollTimeout},
     sys::stat::{fstat, major, minor},
     unistd::{read, write},
 };
@@ -493,7 +493,7 @@ impl HidDeviceBackendBase for HidDevice {
             return Err(HidError::InvalidZeroSizeData);
         }
 
-        Ok(write(self.fd.as_raw_fd(), data)?)
+        Ok(write(self.fd.as_fd(), data)?)
     }
 
     fn read(&self, buf: &mut [u8]) -> HidResult<usize> {
@@ -503,14 +503,18 @@ impl HidDeviceBackendBase for HidDevice {
     }
 
     fn read_timeout(&self, buf: &mut [u8], timeout: i32) -> HidResult<usize> {
-        let pollfd = PollFd::new(&self.fd, PollFlags::POLLIN);
-        let res = poll(&mut [pollfd], timeout)?;
+        let poll_timeout = PollTimeout::try_from(timeout).map_err(|_| HidError::HidApiError {
+            message: format!("invalid timeout value {timeout}"),
+        })?;
+
+        let mut pollfds = [PollFd::new(self.fd.as_fd(), PollFlags::POLLIN)];
+        let res = poll(&mut pollfds, poll_timeout)?;
 
         if res == 0 {
             return Ok(0);
         }
 
-        let events = pollfd
+        let events = pollfds[0]
             .revents()
             .map(|e| e.intersects(PollFlags::POLLERR | PollFlags::POLLHUP | PollFlags::POLLNVAL));
 
@@ -520,7 +524,7 @@ impl HidDeviceBackendBase for HidDevice {
             });
         }
 
-        match read(self.fd.as_raw_fd(), buf) {
+        match read(self.fd.as_fd(), buf) {
             Ok(w) => Ok(w),
             Err(Errno::EAGAIN) | Err(Errno::EINPROGRESS) => Ok(0),
             Err(e) => Err(e.into()),
@@ -616,7 +620,7 @@ impl HidDeviceBackendBase for HidDevice {
     fn get_device_info(&self) -> HidResult<DeviceInfo> {
         // What we have is a descriptor to a file in /dev but we need a syspath
         // so we get the major/minor from there and generate our syspath
-        let devnum = fstat(self.fd.as_raw_fd())?.st_rdev;
+        let devnum = fstat(self.fd.as_fd())?.st_rdev;
         let syspath: PathBuf = format!("/sys/dev/char/{}:{}", major(devnum), minor(devnum)).into();
 
         // The clone is a bit silly but we can't implement Copy. Maybe it's not
@@ -631,7 +635,7 @@ impl HidDeviceBackendBase for HidDevice {
     }
 
     fn get_report_descriptor(&self, buf: &mut [u8]) -> HidResult<usize> {
-        let devnum = fstat(self.fd.as_raw_fd())?.st_rdev;
+        let devnum = fstat(self.fd.as_fd())?.st_rdev;
         let syspath: PathBuf = format!("/sys/dev/char/{}:{}", major(devnum), minor(devnum)).into();
 
         let descriptor = HidrawReportDescriptor::from_syspath(&syspath)?;

--- a/src/windows_native/device_info.rs
+++ b/src/windows_native/device_info.rs
@@ -7,6 +7,10 @@ use crate::windows_native::types::{Handle, InternalBusType};
 use crate::{BusType, DeviceInfo, WcharString};
 use std::ffi::{c_void, CString};
 use std::mem::{size_of, zeroed};
+use windows::Win32::Storage::EnhancedStorage::{
+    PKEY_DeviceInterface_Bluetooth_DeviceAddress, PKEY_DeviceInterface_Bluetooth_Manufacturer,
+    PKEY_DeviceInterface_Bluetooth_ModelNumber,
+};
 use windows_sys::Win32::Devices::HumanInterfaceDevice::{
     HidD_GetManufacturerString, HidD_GetProductString, HidD_GetSerialNumberString,
 };
@@ -14,14 +18,10 @@ use windows_sys::Win32::Devices::Properties::{
     DEVPKEY_Device_CompatibleIds, DEVPKEY_Device_HardwareIds, DEVPKEY_Device_InstanceId,
     DEVPKEY_Device_Manufacturer, DEVPKEY_NAME,
 };
-use windows_sys::Win32::Foundation::{BOOLEAN, HANDLE};
-use windows_sys::Win32::Storage::EnhancedStorage::{
-    PKEY_DeviceInterface_Bluetooth_DeviceAddress, PKEY_DeviceInterface_Bluetooth_Manufacturer,
-    PKEY_DeviceInterface_Bluetooth_ModelNumber,
-};
+use windows_sys::Win32::Foundation::HANDLE;
 
 fn read_string(
-    func: unsafe extern "system" fn(HANDLE, *mut c_void, u32) -> BOOLEAN,
+    func: unsafe extern "system" fn(HANDLE, *mut c_void, u32) -> bool,
     handle: &Handle,
 ) -> WcharString {
     // Return empty string on failure to match the c implementation
@@ -32,8 +32,7 @@ fn read_string(
             string.as_mut_ptr() as _,
             (size_of::<u16>() * string.len()) as u32,
         )
-    } != 0
-    {
+    } {
         U16Str::from_slice_list(&string)
             .map(WcharString::from)
             .next()

--- a/src/windows_native/device_info.rs
+++ b/src/windows_native/device_info.rs
@@ -7,10 +7,7 @@ use crate::windows_native::types::{Handle, InternalBusType};
 use crate::{BusType, DeviceInfo, WcharString};
 use std::ffi::{c_void, CString};
 use std::mem::{size_of, zeroed};
-use windows::Win32::Storage::EnhancedStorage::{
-    PKEY_DeviceInterface_Bluetooth_DeviceAddress, PKEY_DeviceInterface_Bluetooth_Manufacturer,
-    PKEY_DeviceInterface_Bluetooth_ModelNumber,
-};
+use windows_sys::core::GUID;
 use windows_sys::Win32::Devices::HumanInterfaceDevice::{
     HidD_GetManufacturerString, HidD_GetProductString, HidD_GetSerialNumberString,
 };
@@ -18,7 +15,25 @@ use windows_sys::Win32::Devices::Properties::{
     DEVPKEY_Device_CompatibleIds, DEVPKEY_Device_HardwareIds, DEVPKEY_Device_InstanceId,
     DEVPKEY_Device_Manufacturer, DEVPKEY_NAME,
 };
-use windows_sys::Win32::Foundation::HANDLE;
+use windows_sys::Win32::Foundation::{HANDLE, PROPERTYKEY};
+
+// These constants are only part of the heavyweight `windows` and not `windows-sys`,
+// so we manually define them here.
+#[allow(nonstandard_style)]
+const PKEY_DeviceInterface_Bluetooth_DeviceAddress: PROPERTYKEY = PROPERTYKEY {
+    fmtid: GUID::from_u128(0x2bd67d8b_8beb_48d5_87e0_6cda3428040a),
+    pid: 1,
+};
+#[allow(nonstandard_style)]
+const PKEY_DeviceInterface_Bluetooth_Manufacturer: PROPERTYKEY = PROPERTYKEY {
+    fmtid: GUID::from_u128(0x2bd67d8b_8beb_48d5_87e0_6cda3428040a),
+    pid: 4,
+};
+#[allow(nonstandard_style)]
+const PKEY_DeviceInterface_Bluetooth_ModelNumber: PROPERTYKEY = PROPERTYKEY {
+    fmtid: GUID::from_u128(0x2bd67d8b_8beb_48d5_87e0_6cda3428040a),
+    pid: 5,
+};
 
 fn read_string(
     func: unsafe extern "system" fn(HANDLE, *mut c_void, u32) -> bool,

--- a/src/windows_native/error.rs
+++ b/src/windows_native/error.rs
@@ -55,8 +55,8 @@ pub fn check_config(ret: CONFIGRET, expected: CONFIGRET) -> WinResult<()> {
     }
 }
 
-pub fn check_boolean(ret: BOOLEAN) -> WinResult<()> {
-    if ret == 0 {
+pub fn check_boolean(ret: bool) -> WinResult<()> {
+    if !ret {
         Err(Win32Error::last().into())
     } else {
         Ok(())

--- a/src/windows_native/mod.rs
+++ b/src/windows_native/mod.rs
@@ -80,6 +80,8 @@ pub struct HidDevice {
     feature_state: RefCell<AsyncState>,
 }
 
+unsafe impl Send for HidDevice {}
+
 struct AsyncState {
     overlapped: Box<Overlapped>,
     buffer: Vec<u8>,
@@ -390,7 +392,7 @@ fn open_device(path: &U16Str, open_rw: bool) -> WinResult<Handle> {
             null(),
             OPEN_EXISTING,
             FILE_FLAG_OVERLAPPED,
-            0,
+            null_mut(),
         )
     };
     ensure!(

--- a/src/windows_native/types.rs
+++ b/src/windows_native/types.rs
@@ -2,12 +2,14 @@ use crate::windows_native::error::{WinError, WinResult};
 use crate::BusType;
 use std::mem::{size_of, zeroed};
 use std::ptr::null;
+use windows::Win32::Foundation::PROPERTYKEY;
 use windows_sys::core::GUID;
-use windows_sys::Win32::Devices::Properties::{DEVPROPKEY, DEVPROPTYPE, DEVPROP_TYPE_GUID};
-use windows_sys::Win32::Foundation::{CloseHandle, FALSE, HANDLE, INVALID_HANDLE_VALUE, TRUE};
+use windows_sys::Win32::Devices::Properties::{DEVPROPTYPE, DEVPROP_TYPE_GUID};
+use windows_sys::Win32::Foundation::{
+    CloseHandle, DEVPROPKEY, FALSE, HANDLE, INVALID_HANDLE_VALUE, TRUE,
+};
 use windows_sys::Win32::System::Threading::{CreateEventW, INFINITE};
 use windows_sys::Win32::System::IO::{GetOverlappedResultEx, OVERLAPPED};
-use windows_sys::Win32::UI::Shell::PropertiesSystem::PROPERTYKEY;
 
 #[allow(clippy::missing_safety_doc)]
 pub unsafe trait DeviceProperty {

--- a/src/windows_native/types.rs
+++ b/src/windows_native/types.rs
@@ -2,11 +2,10 @@ use crate::windows_native::error::{WinError, WinResult};
 use crate::BusType;
 use std::mem::{size_of, zeroed};
 use std::ptr::null;
-use windows::Win32::Foundation::PROPERTYKEY;
 use windows_sys::core::GUID;
 use windows_sys::Win32::Devices::Properties::{DEVPROPTYPE, DEVPROP_TYPE_GUID};
 use windows_sys::Win32::Foundation::{
-    CloseHandle, DEVPROPKEY, FALSE, HANDLE, INVALID_HANDLE_VALUE, TRUE,
+    CloseHandle, DEVPROPKEY, FALSE, HANDLE, INVALID_HANDLE_VALUE, PROPERTYKEY, TRUE,
 };
 use windows_sys::Win32::System::Threading::{CreateEventW, INFINITE};
 use windows_sys::Win32::System::IO::{GetOverlappedResultEx, OVERLAPPED};


### PR DESCRIPTION
This PR is the result of `cargo upgrade --incompatible --pinned --ignore-rust-version --recursive` and manual modifications to account for the changes in the upstream crates.

`windows-sys` 0.61.x is very important for me, because it consistently uses `raw-dylib` for importing APIs from Windows DLLs. This makes a huge difference when using non-MSVC toolchains to build Windows binaries, e.g. `x86_64-pc-windows-gnullvm`.

Unfortunately, `Win32_Storage_EnhancedStorage` is only available in the heavyweight `windows` crate these days, which is why I also need to import that one. However, I'm only importing it for that one feature and continue to use `windows-sys` for the rest of the code.

CC @ruabmbua