### PR TITLE
linux-native: Change ioctls back to readwrite, to match kernel definitions

### DIFF
--- a/src/linux_native.rs
+++ b/src/linux_native.rs
@@ -536,7 +536,14 @@ impl HidDeviceBackendBase for HidDevice {
             return Err(HidError::InvalidZeroSizeData);
         }
 
-        let res = match unsafe { hidraw_ioc_set_feature(self.fd.as_raw_fd(), data) } {
+        // Have to crate owned buffer, because its not safe to cast shared
+        // reference to mutable reference, even if the underlying function never
+        // tries to mutate it.
+        let mut d = data.to_vec();
+
+        // The ioctl is marked as read-write so we need to mess with the
+        // mutability even though nothing should get written
+        let res = match unsafe { hidraw_ioc_set_feature(self.fd.as_raw_fd(), &mut d) } {
             Ok(n) => n as usize,
             Err(e) => {
                 return Err(HidError::HidApiError {

--- a/src/linux_native.rs
+++ b/src/linux_native.rs
@@ -576,7 +576,14 @@ impl HidDeviceBackendBase for HidDevice {
     }
 
     fn send_output_report(&self, buf: &[u8]) -> HidResult<()> {
-        let res = match unsafe { hidraw_ioc_set_output(self.fd.as_raw_fd(), buf) } {
+        // Have to crate owned buffer, because its not safe to cast shared
+        // reference to mutable reference, even if the underlying function never
+        // tries to mutate it.
+        let mut d = buf.to_vec();
+
+        // The ioctl is marked as read-write so we need to mess with the
+        // mutability even though nothing should get written
+        let res = match unsafe { hidraw_ioc_set_output(self.fd.as_raw_fd(), &mut d) } {
             Ok(n) => n,
             Err(e) => {
                 return Err(HidError::HidApiError {

--- a/src/linux_native/ioctl.rs
+++ b/src/linux_native/ioctl.rs
@@ -29,10 +29,15 @@ ioctl_readwrite_buf!(
     HIDRAW_GET_FEATURE,
     u8
 );
-ioctl_write_buf!(
+ioctl_readwrite_buf!(
     hidraw_ioc_set_output,
     HIDRAW_IOC_MAGIC,
     HIDRAW_SET_OUTPUT,
     u8
 );
-ioctl_read_buf!(hidraw_ioc_get_input, HIDRAW_IOC_MAGIC, HIDRAW_GET_INPUT, u8);
+ioctl_readwrite_buf!(
+    hidraw_ioc_get_input,
+    HIDRAW_IOC_MAGIC,
+    HIDRAW_GET_INPUT,
+    u8
+);

--- a/src/linux_native/ioctl.rs
+++ b/src/linux_native/ioctl.rs
@@ -1,6 +1,6 @@
 //! The IOCTL calls we need for the native linux backend
 
-use nix::{ioctl_read, ioctl_read_buf, ioctl_write_buf};
+use nix::{ioctl_read, ioctl_readwrite_buf};
 
 // From linux/hidraw.h
 const HIDRAW_IOC_MAGIC: u8 = b'H';
@@ -17,13 +17,13 @@ ioctl_read!(
     libc::c_int
 );
 
-ioctl_write_buf!(
+ioctl_readwrite_buf!(
     hidraw_ioc_set_feature,
     HIDRAW_IOC_MAGIC,
     HIDRAW_SET_FEATURE,
     u8
 );
-ioctl_read_buf!(
+ioctl_readwrite_buf!(
     hidraw_ioc_get_feature,
     HIDRAW_IOC_MAGIC,
     HIDRAW_GET_FEATURE,


### PR DESCRIPTION
Here are the definitions from the kernel:
```c
#define HIDIOCSFEATURE(len)    _IOC(_IOC_WRITE|_IOC_READ, 'H', 0x06, len)
#define HIDIOCGFEATURE(len)    _IOC(_IOC_WRITE|_IOC_READ, 'H', 0x07, len)
#define HIDIOCSOUTPUT(len)    _IOC(_IOC_WRITE|_IOC_READ, 'H', 0x0B, len)
#define HIDIOCGOUTPUT(len)    _IOC(_IOC_WRITE|_IOC_READ, 'H', 0x0C, len)
```

Using read and write instead of readwrite meant we were trying to use an invalid ioctl number, causing the ioctl to return EINVAL (at least on my system...). I should note I have only tested `HIDIOCSFEATURE`, though.

Happy to make this one commit instead of a revert and a commit to fix the other features that have been added since (outputs) if that's preferred.